### PR TITLE
Fixes storybook start dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ node_modules
 
 # webstrom
 .idea
+
+# storybook
+.storybook/temp

--- a/.storybook/tsconfig.json
+++ b/.storybook/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "jsx": "react",
+    "outDir": "./temp",
+    "declaration": true,
+    "sourceMap": true,
+    "removeComments": true,
+    "strict": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "allowSyntheticDefaultImports": false
+  },
+
+  "include": [
+    "./src"
+  ],
+  "exclude": [
+    "./src/**/spec.tsx"
+  ]
+}

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -5,7 +5,10 @@ module.exports = (baseConfig, env) => {
   const config = genDefaultConfig(baseConfig, env)
   config.module.rules.push({
     test: /\.(ts|tsx)$/,
-    loader: require.resolve('awesome-typescript-loader')
+    loader: require.resolve('awesome-typescript-loader'),
+    options: {
+      configFileName: './.storybook/tsconfig.json'
+    }
   })
   config.resolve.extensions.push('.ts', '.tsx')
   return config

--- a/src/features/rewards/panelSummary/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/panelSummary/__snapshots__/spec.tsx.snap
@@ -263,7 +263,7 @@ exports[`PanelSummary tests basic tests matches the snapshot 1`] = `
   <div
     className="c2"
   >
-    MISSING: monthJul
+    MISSING: monthAug
      
     2018
   </div>


### PR DESCRIPTION
This add target dir for storybook when we are using it for development. This way it will not generate storybook files into the package folder.