### PR TITLE
add card component

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -8,6 +8,7 @@ import Modal from './popupModals/modal'
 import Select from './formControls/select'
 import Table from './dataTables/table'
 import Tabs from './layout/tabs'
+import Card from './layout/card'
 import TextArea from './formControls/textarea'
 import Toggle from './formControls/toggle'
 import { Grid, Column } from './layout/gridList'
@@ -21,6 +22,7 @@ export {
   Select,
   Table,
   Tabs,
+  Card,
   TextArea,
   Toggle
 }

--- a/src/components/layout/card/__snapshots__/spec.tsx.snap
+++ b/src/components/layout/card/__snapshots__/spec.tsx.snap
@@ -2,8 +2,12 @@
 
 exports[`card tests basic tests matches the snapshot 1`] = `
 .c0 {
-  padding: 40px;
-  background-color: #FFF;
+  max-width: 100%;
+  width: 100%;
+  min-height: auto;
+  margin: 0;
+  padding: 30px 36px;
+  background-color: #fff;
   border-radius: 6px;
   box-shadow: 0 0 8px 0 rgba(99,105,110,0.12);
   font-size: inherit;
@@ -13,6 +17,6 @@ exports[`card tests basic tests matches the snapshot 1`] = `
 
 <div
   className="c0"
-  id="testCard"
+  data-test-id="testCard"
 />
 `;

--- a/src/components/layout/card/__snapshots__/spec.tsx.snap
+++ b/src/components/layout/card/__snapshots__/spec.tsx.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`card tests basic tests matches the snapshot 1`] = `
+.c0 {
+  padding: 40px;
+  background-color: #FFF;
+  border-radius: 6px;
+  box-shadow: 0 0 8px 0 rgba(99,105,110,0.12);
+  font-size: inherit;
+  box-sizing: border-box;
+  position: relative;
+}
+
+<div
+  className="c0"
+  id="testCard"
+/>
+`;

--- a/src/components/layout/card/index.tsx
+++ b/src/components/layout/card/index.tsx
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as React from 'react'
+import * as CSS from 'csstype'
+
+import StyledCard from './style'
+
+export interface CardTheme {
+  maxWidth?: CSS.MaxWidthProperty<1>
+  width?: CSS.WidthProperty<1>
+  minHeight?: CSS.MinHeightProperty<1>
+  margin?: CSS.MarginProperty<1>
+  padding?: CSS.PaddingProperty<1>
+  backgroundColor?: CSS.BackgroundColorProperty
+  boxShadow?: CSS.BoxShadowProperty
+}
+
+export interface CardProps {
+  id?: string
+  theme?: CardTheme
+  children?: React.ReactNode
+}
+
+class Card extends React.PureComponent<CardProps, {}> {
+  render () {
+    const { id, theme, children } = this.props
+    return (
+      <StyledCard id={id} theme={theme}>{children}</StyledCard>
+    )
+  }
+}
+
+export default Card

--- a/src/components/layout/card/index.tsx
+++ b/src/components/layout/card/index.tsx
@@ -3,33 +3,25 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import * as React from 'react'
-import * as CSS from 'csstype'
 
-import StyledCard from './style'
-
-export interface CardTheme {
-  maxWidth?: CSS.MaxWidthProperty<1>
-  width?: CSS.WidthProperty<1>
-  minHeight?: CSS.MinHeightProperty<1>
-  margin?: CSS.MarginProperty<1>
-  padding?: CSS.PaddingProperty<1>
-  backgroundColor?: CSS.BackgroundColorProperty
-  boxShadow?: CSS.BoxShadowProperty
-}
+import { StyledCard } from './style'
 
 export interface CardProps {
-  id?: string
-  theme?: CardTheme
+  testId?: string
   children?: React.ReactNode
 }
 
-class Card extends React.PureComponent<CardProps, {}> {
+/**
+ * Card Component
+ * Styled block simulating a *card* style usually made as a styled wrapper
+ * @prop {string} testId - the test id to be used for testing
+ * @prop {React.ReactNode} children - the child components/elements to be included
+ */
+export default class Card extends React.PureComponent<CardProps, {}> {
   render () {
-    const { id, theme, children } = this.props
+    const { testId, children } = this.props
     return (
-      <StyledCard id={id} theme={theme}>{children}</StyledCard>
+      <StyledCard data-test-id={testId}>{children}</StyledCard>
     )
   }
 }
-
-export default Card

--- a/src/components/layout/card/spec.tsx
+++ b/src/components/layout/card/spec.tsx
@@ -1,0 +1,32 @@
+/* global jest, expect, describe, it, afterEach */
+import * as React from 'react'
+import { shallow } from 'enzyme'
+import { create } from 'react-test-renderer'
+import Card from './index'
+
+describe('card tests', () => {
+  const baseComponent = (props?: object) => (
+    <Card id='testCard' {...props} />
+  )
+  describe('basic tests', () => {
+    it('matches the snapshot', () => {
+      const component = baseComponent()
+      const tree = create(component).toJSON()
+      expect(tree).toMatchSnapshot()
+    })
+
+    it('renders the component', () => {
+      const wrapper = shallow(baseComponent({id: 'toughCard'}))
+      const assertion = wrapper.find('#toughCard').length
+      expect(assertion).toBe(1)
+    })
+  })
+
+  describe('component behavior', () => {
+    it('can have an id', () => {
+      const wrapper = shallow(baseComponent({id: 'boxedThing'}))
+      const assertion = wrapper.props().id
+      expect(assertion).toBe('boxedThing')
+    })
+  })
+})

--- a/src/components/layout/card/spec.tsx
+++ b/src/components/layout/card/spec.tsx
@@ -6,7 +6,7 @@ import Card from './index'
 
 describe('card tests', () => {
   const baseComponent = (props?: object) => (
-    <Card id='testCard' {...props} />
+    <Card testId='testCard' {...props} />
   )
   describe('basic tests', () => {
     it('matches the snapshot', () => {
@@ -16,17 +16,9 @@ describe('card tests', () => {
     })
 
     it('renders the component', () => {
-      const wrapper = shallow(baseComponent({id: 'toughCard'}))
-      const assertion = wrapper.find('#toughCard').length
-      expect(assertion).toBe(1)
-    })
-  })
-
-  describe('component behavior', () => {
-    it('can have an id', () => {
-      const wrapper = shallow(baseComponent({id: 'boxedThing'}))
-      const assertion = wrapper.props().id
-      expect(assertion).toBe('boxedThing')
+      const wrapper = shallow(baseComponent({testId: 'toughCard'}))
+      const assertion = wrapper.props()['data-test-id']
+      expect(assertion).toBe('toughCard')
     })
   })
 })

--- a/src/components/layout/card/style.ts
+++ b/src/components/layout/card/style.ts
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License. v. 2.0. If a copy of the MPL was not distributed with this file.
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import styled from 'styled-components'
+import { CardProps } from './index'
+import { setTheme } from '../../../helpers'
+
+const StyledCard = styled.div`
+  max-width: ${(p: CardProps) => setTheme(p.theme, 'maxWidth')};
+  width: ${(p: CardProps) => setTheme(p.theme, 'width')};
+  min-height: ${(p: CardProps) => setTheme(p.theme, 'minHeight')};
+  margin: ${(p: CardProps) => setTheme(p.theme, 'margin')};
+  padding: ${(p: CardProps) => setTheme(p.theme, 'padding') || '40px'};
+  background-color: ${(p: CardProps) => setTheme(p.theme, 'backgroundColor') || '#FFF'};
+  border-radius: ${(p: CardProps) => setTheme(p.theme, 'borderRadius') || '6px'};
+  box-shadow: ${(p: CardProps) => setTheme(p.theme, 'boxShadow') || '0 0 8px 0 rgba(99,105,110,0.12)'};
+  font-size: inherit;
+  box-sizing: border-box;
+  position: relative;
+` as any
+
+export default StyledCard

--- a/src/components/layout/card/style.ts
+++ b/src/components/layout/card/style.ts
@@ -4,20 +4,17 @@
 
 import styled from 'styled-components'
 import { CardProps } from './index'
-import { setTheme } from '../../../helpers'
 
-const StyledCard = styled.div`
-  max-width: ${(p: CardProps) => setTheme(p.theme, 'maxWidth')};
-  width: ${(p: CardProps) => setTheme(p.theme, 'width')};
-  min-height: ${(p: CardProps) => setTheme(p.theme, 'minHeight')};
-  margin: ${(p: CardProps) => setTheme(p.theme, 'margin')};
-  padding: ${(p: CardProps) => setTheme(p.theme, 'padding') || '40px'};
-  background-color: ${(p: CardProps) => setTheme(p.theme, 'backgroundColor') || '#FFF'};
-  border-radius: ${(p: CardProps) => setTheme(p.theme, 'borderRadius') || '6px'};
-  box-shadow: ${(p: CardProps) => setTheme(p.theme, 'boxShadow') || '0 0 8px 0 rgba(99,105,110,0.12)'};
+export const StyledCard = styled<CardProps, 'div'>('div')`
+  max-width: 100%;
+  width: 100%;
+  min-height: auto;
+  margin: 0;
+  padding: 30px 36px;
+  background-color: #fff;
+  border-radius: 6px;
+  box-shadow: 0 0 8px 0 rgba(99,105,110,0.12);
   font-size: inherit;
   box-sizing: border-box;
   position: relative;
-` as any
-
-export default StyledCard
+`

--- a/stories/components/layout.tsx
+++ b/stories/components/layout.tsx
@@ -12,7 +12,7 @@ import * as React from 'react'
 import { withState } from '@dump247/storybook-state'
 
 // Components
-import { Tabs, Column, Grid } from '../../src/components'
+import { Tabs, Column, Grid, Card } from '../../src/components'
 
 storiesOf('Components/Layout', module)
   .addDecorator(withKnobs)
@@ -104,5 +104,22 @@ storiesOf('Components/Layout', module)
           </Column>
         </Grid>
       </div>
+    )
+  })
+  .add('Card', () => {
+    return (
+      <Card
+        theme={{
+          margin: text('Margin', '0px'),
+          padding: text('Padding', ''),
+          minHeight: text('Min Height', '150px'),
+          width: text('Width', '400px'),
+          maxWidth: text('Max Width', '100%'),
+          boxShadow: text('Box Shadow', ''),
+          backgroundColor: text('Background Color', 'white')
+        }}
+      >
+        <p>Hello I'm a card!</p>
+      </Card>
     )
   })

--- a/stories/components/layout.tsx
+++ b/stories/components/layout.tsx
@@ -108,17 +108,7 @@ storiesOf('Components/Layout', module)
   })
   .add('Card', () => {
     return (
-      <Card
-        theme={{
-          margin: text('Margin', '0px'),
-          padding: text('Padding', ''),
-          minHeight: text('Min Height', '150px'),
-          width: text('Width', '400px'),
-          maxWidth: text('Max Width', '100%'),
-          boxShadow: text('Box Shadow', ''),
-          backgroundColor: text('Background Color', 'white')
-        }}
-      >
+      <Card>
         <p>Hello I'm a card!</p>
       </Card>
     )

--- a/stories/features/welcome/page/index.tsx
+++ b/stories/features/welcome/page/index.tsx
@@ -8,7 +8,6 @@ import Page from '../../../../src/old/page/index'
 import { Heading } from '../../../../src/old/headings/index'
 import Paragraph from '../../../../src/old/paragraph/index'
 import { Grid, Column } from '../../../../src/components/layout/gridList/index'
-import Panel from '../../../../src/old/v1/panel/index'
 import UnstyledButton from '../../../../src/old/unstyledButton/index'
 import { PushButton } from '../../../../src/old/v1/pushButton/index'
 import Image from '../../../../src/old/v1/image/index'
@@ -231,10 +230,10 @@ class WelcomePage extends React.PureComponent<{}, WelcomePageState> {
         }}
       >
         <Page customStyle={customStyle.welcomePage}>
-          <Panel customStyle={customStyle.panel}>
+          <div style={customStyle.panel}>
             {this.currentScreen}
             {this.footer}
-          </Panel>
+          </div>
         </Page>
       </div>
     )

--- a/stories/features/welcome/page/theme.ts
+++ b/stories/features/welcome/page/theme.ts
@@ -14,6 +14,11 @@ const theme = {
     width: '-webkit-fill-available'
   },
   panel: {
+    width: '-webkit-fill-available',
+    margin: '0',
+    fontSize: 'inherit',
+    boxSizing: 'border-box',
+    position: 'relative',
     backgroundColor: 'rgba(255,255,255,0.95)',
     borderRadius: '20px',
     boxShadow: '0 6px 12px 0 rgba(39, 46, 64, 0.2)',

--- a/stories/features/welcome/page/theme.ts
+++ b/stories/features/welcome/page/theme.ts
@@ -15,6 +15,8 @@ const theme = {
   },
   panel: {
     backgroundColor: 'rgba(255,255,255,0.95)',
+    borderRadius: '20px',
+    boxShadow: '0 6px 12px 0 rgba(39, 46, 64, 0.2)',
     maxWidth: '600px',
     minHeight: '580px',
     display: 'flex',


### PR DESCRIPTION
Added card component previously called panel. there's a component in rewards with the same name so I had to adapt. I like it tho.

Ideally, the rewards components should re-use it so one-change-changes-it-all but left them as-is for now. Welcome page was updated to make use of it.