### PR TITLE
Get a Storybook for each PR via `now` deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ node_modules
 
 # storybook
 .storybook/temp
+.storybook-out
+.out
 
 # package
 package

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:8
+
+RUN mkdir -p /app
+WORKDIR /app
+ADD package.json /app
+RUN npm install
+COPY . /app
+RUN npm run storybook-build
+
+FROM kyma/docker-nginx
+COPY --from=0 /app/.storybook-out /var/www
+CMD ["nginx"]

--- a/now.json
+++ b/now.json
@@ -1,0 +1,3 @@
+{
+  "type": "docker"
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "publish": "npm run build && lerna publish",
     "storybook-start": "start-storybook -p 9091 -c .storybook",
     "storybook-deploy": "storybook-to-ghpages -s public -o .out",
+    "storybook-build": "build-storybook -c .storybook -o .storybook-out",
     "test-unit": "jest -t",
     "test-unit-all": "jest --verbose",
     "test-security": "npm audit",


### PR DESCRIPTION
**Please do not merge until security review passes**

This provides config so that developers can simply run the `now` command inside the repo at any time and get a permanent public Url for that version that can be shared with other team members.

The main aim though is to have `now` create a public Url for each PR so that we can easily see the Storybook for the code in that PR. I've submitted a security review for that.

I decided to use docker so that we're serving a static version of storybook, instead of the hot-reload dev server. Save the trees.

Here's an example of a deployment: https://brave-ui-roywtrxoei.now.sh