### PR TITLE
Added data-test-id for opt-in button testing

### DIFF
--- a/src/features/rewards/welcomePage/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/welcomePage/__snapshots__/spec.tsx.snap
@@ -480,6 +480,7 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
             <div
               className="c12"
               color="subtle"
+              data-test-id="optInAction"
               onClick={undefined}
               size="large"
             >

--- a/src/features/rewards/welcomePage/index.tsx
+++ b/src/features/rewards/welcomePage/index.tsx
@@ -101,6 +101,7 @@ class WelcomePage extends React.PureComponent<Props, {}> {
             color='subtle'
             text={getLocale('braveRewardsOptInText')}
             onClick={this.props.optInAction}
+            data-test-id='optInAction'
           />
         </StyledOptInSection>
         <StyledSection>


### PR DESCRIPTION
Need to grab DOM elements for testing. Added data-test-id to welcome page opt-in button.