### PR TITLE
Fixing test-unit-all on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ branches:
     - master
 env:
   - TEST_SUITE=lint
-  - TEST_SUITE=test-unit-all
+  - TEST_SUITE=test-unit-all-ci
   - TEST_SUITE=test-security
 script:
   - npm run $TEST_SUITE

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "storybook-build": "build-storybook -c .storybook -o .storybook-out",
     "test-unit": "jest -t",
     "test-unit-all": "jest --verbose",
+    "test-unit-all-ci": "jest --verbose --maxWorkers=4",
     "test-security": "npm audit",
     "coverage": "jest --coverage --verbose",
     "create": "node ./tools/createComponent.js"


### PR DESCRIPTION
By limiting `maxWorkers` to 4 we can greatly increase the speed of `test-unit-all`. Two examples:

https://travis-ci.org/brave/brave-ui/builds/422796662?utm_source=github_status&utm_medium=notification
https://travis-ci.org/brave/brave-ui/builds/422798386?utm_source=github_status&utm_medium=notification