### PR TITLE
let onRestore prop be optional in modalContribute

### DIFF
--- a/src/features/rewards/modalContribute/index.tsx
+++ b/src/features/rewards/modalContribute/index.tsx
@@ -18,7 +18,7 @@ import { getLocale } from '../../../helpers'
 export interface Props {
   rows: DetailRow[]
   onClose: () => void
-  onRestore: () => void
+  onRestore?: () => void
   id?: string
   numExcludedSites?: number
 }


### PR DESCRIPTION
fix #149

component interface says that `onRestore` is required (see [here](https://github.com/brave/brave-ui/blob/master/src/features/rewards/modalContribute/index.tsx#L21)) but implementation doesn't use it (see [here](https://github.com/brave/brave-ui/blob/master/stories/features/rewards/settings/contributeBox.tsx#L169)).