### PR TITLE
Fixes recovery key text area background on Linux

### DIFF
--- a/src/components/formControls/textarea/__snapshots__/spec.tsx.snap
+++ b/src/components/formControls/textarea/__snapshots__/spec.tsx.snap
@@ -18,6 +18,10 @@ exports[`TextArea tests basic tests matches the snapshot 1`] = `
   line-height: 26px;
 }
 
+.c1:disabled {
+  background: #fff;
+}
+
 .c1:focus {
   border-color: #A1A8F2;
   outline: none;

--- a/src/components/formControls/textarea/style.ts
+++ b/src/components/formControls/textarea/style.ts
@@ -21,6 +21,10 @@ export const StyledArea = styled<Props, 'textarea'>('textarea')`
   font-size: 16px;
   line-height: 26px;
 
+  &:disabled {
+    background: #fff;
+  }
+
   &:focus {
     border-color: #A1A8F2;
     outline: none;

--- a/src/features/rewards/modalBackupRestore/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/modalBackupRestore/__snapshots__/spec.tsx.snap
@@ -300,6 +300,10 @@ exports[`ModalBackupRestore tests basic tests matches the snapshot 1`] = `
   line-height: 26px;
 }
 
+.c14:disabled {
+  background: #fff;
+}
+
 .c14:focus {
   border-color: #A1A8F2;
   outline: none;


### PR DESCRIPTION
Fixes #130 

Fix confirmed on Ubuntu 18.04.1

