### PR TITLE
Removing flex transition for Box

### DIFF
--- a/src/features/rewards/box/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/box/__snapshots__/spec.tsx.snap
@@ -18,30 +18,20 @@ exports[`Box tests basic tests matches the snapshot 1`] = `
 .c0 {
   margin-bottom: 28px;
   font-family: Poppins,sans-serif;
-  overflow: hidden;
 }
 
 .c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  width: 200%;
-  overflow: hidden;
+  display: block;
 }
 
 .c3 {
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-basis: 50%;
-  -ms-flex-preferred-size: 50%;
-  flex-basis: 50%;
-  margin-left: 0;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
 }
 
 .c4 {
@@ -125,9 +115,7 @@ exports[`Box tests basic tests matches the snapshot 1`] = `
 .c10 {
   background: #fff;
   overflow: hidden;
-  -webkit-flex-basis: 50%;
-  -ms-flex-preferred-size: 50%;
-  flex-basis: 50%;
+  display: none;
 }
 
 .c11 {

--- a/src/features/rewards/box/index.tsx
+++ b/src/features/rewards/box/index.tsx
@@ -123,23 +123,18 @@ export default class Box extends React.PureComponent<Props, State> {
               }
             </StyledContent>
           </StyledContentWrapper>
-          {
-            !isDisabled
-            ? <StyledSettingsWrapper open={this.state.settingsOpened}>
-              <StyledSettingsClose onClick={this.settingsClick} open={this.state.settingsOpened}>
-                <CloseStrokeIcon />
-              </StyledSettingsClose>
-              <StyledSettingsTitle>
-                <StyledSettingsIcon>
-                  <SettingsIcon />
-                </StyledSettingsIcon>
-                <StyledSettingsText>{this.getSettingsTitle(title)}</StyledSettingsText>
-              </StyledSettingsTitle>
-              {settingsChild}
-            </StyledSettingsWrapper>
-            : null
-          }
-
+          <StyledSettingsWrapper open={this.state.settingsOpened}>
+            <StyledSettingsClose onClick={this.settingsClick} open={this.state.settingsOpened}>
+              <CloseStrokeIcon />
+            </StyledSettingsClose>
+            <StyledSettingsTitle>
+              <StyledSettingsIcon>
+                <SettingsIcon />
+              </StyledSettingsIcon>
+              <StyledSettingsText>{this.getSettingsTitle(title)}</StyledSettingsText>
+            </StyledSettingsTitle>
+            {settingsChild}
+          </StyledSettingsWrapper>
         </StyledFlip>
       </StyledCard>
     )

--- a/src/features/rewards/box/style.ts
+++ b/src/features/rewards/box/style.ts
@@ -23,20 +23,15 @@ const colors: Record<Type, string> = {
 export const StyledCard = styled(Card as ComponentType<CardProps>)`
   margin-bottom: 28px;
   font-family: Poppins, sans-serif;
-  overflow: hidden;
 `
 
 export const StyledFlip = styled<StyleProps, 'div'>('div')`
-  display: flex;
-  width: 200%;
-  overflow: hidden;
+  display: block;
 `
 
 export const StyledContentWrapper = styled<StyleProps, 'div'>('div')`
-  display: flex;
-  flex-basis: 50%;
-  margin-left: ${p => p.open ? '0' : '-50%'};
   flex-wrap: wrap;
+  display: ${p => p.open ? 'flex' : 'none'};
 `
 
 export const StyledLeft = styled<{}, 'div'>('div')`
@@ -97,7 +92,7 @@ export const StyledContent = styled<{}, 'div'>('div')`
 export const StyledSettingsWrapper = styled<StyleProps, 'div'>('div')`
   background: #fff;
   overflow: hidden;
-  flex-basis: 50%;
+  display: ${p => p.open ? 'block' : 'none'};
 `
 
 export const StyledSettingsClose = styled<StyleProps, 'button'>('button')`


### PR DESCRIPTION
A couple things should be checked here:

1. Showing/hiding the settings section on contribution and donation boxes should behave exactly the same.
2. The settings icon tooltip on those respective boxes should overflow and not clip in to the parent container.