### PR TITLE
Make "FAQ" link within "Add Funds" open a new tab

### DIFF
--- a/src/features/rewards/modalAddFunds/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/modalAddFunds/__snapshots__/spec.tsx.snap
@@ -135,6 +135,7 @@ exports[`ModalAddFunds tests basic tests matches the snapshot 1`] = `
           <a
             className="c9"
             href="https://brave.com/faq-payments/#brave-payments"
+            target="_blank"
           >
             MISSING: addFundsFAQ
           </a>

--- a/src/features/rewards/modalAddFunds/index.tsx
+++ b/src/features/rewards/modalAddFunds/index.tsx
@@ -121,7 +121,7 @@ export default class ModalAddFunds extends React.PureComponent<Props, State> {
             }
           </StyledAddresses>
           <StyledNote>
-            {getLocale('addFundsNote')} <StyledLink href='https://brave.com/faq-payments/#brave-payments'>
+            {getLocale('addFundsNote')} <StyledLink href='https://brave.com/faq-payments/#brave-payments' target={'_blank'}>
               {getLocale('addFundsFAQ')}
               </StyledLink>.
           </StyledNote>


### PR DESCRIPTION
This PR resolves https://github.com/brave/brave-browser/issues/1414 by adding a `target="_blank"` to the FAQ link in the Add Funds modal.

To test:
- Navigate to the Add Funds page
- Click "FAQ"
- Observe the FAQ page opens in a new tab instead of navigating the current tab.

cc'ing @cezaraugusto as per the contributing page. Let me know if anything is out of order :)

Much love for this project <3