### PR TITLE
Fix types

### DIFF
--- a/src/features/rewards/amount/index.tsx
+++ b/src/features/rewards/amount/index.tsx
@@ -10,7 +10,7 @@ import { BatColorIcon } from '../../../components/icons'
 export interface Props {
   amount: string
   converted: string
-  onSelect: (amount: number) => void
+  onSelect: (amount: string) => void
   id?: string
   selected?: boolean
   type?: 'big' | 'small'
@@ -21,7 +21,7 @@ export default class Amount extends React.PureComponent<Props, {}> {
   static defaultProps = {
     type: 'small',
     currency: 'USD',
-    converted: 0
+    converted: '0.00'
   }
 
   render () {

--- a/src/features/rewards/amount/spec.tsx
+++ b/src/features/rewards/amount/spec.tsx
@@ -6,7 +6,7 @@ import Amount from './index'
 import { TestThemeProvider } from '../../../theme'
 
 describe('Amount tests', () => {
-  const baseComponent = (props?: object) => <TestThemeProvider><Amount id='amount' amount={1} converted={0.4} onSelect={() => {}} {...props}  /></TestThemeProvider>
+  const baseComponent = (props?: object) => <TestThemeProvider><Amount id='amount' amount={'1'} converted={'0.4'} onSelect={() => {}} {...props} /></TestThemeProvider>
 
   describe('basic tests', () => {
     it('matches the snapshot', () => {


### PR DESCRIPTION
This PR fixes the type of Amount props in `src/features/rewards/amount/index.tsx`: 
* amount: `string` -> `number`
* converted: `string` -> `number`
