### PR TITLE
Welcome page tweaks

### DIFF
--- a/src/features/rewards/hero/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/hero/__snapshots__/spec.tsx.snap
@@ -12,6 +12,12 @@ exports[`Hero tests basic tests matches the snapshot 1`] = `
   border-bottom-right-radius: 150% 120px;
 }
 
+@media (max-width:475px) {
+  .c0 {
+    padding-top: 35px;
+  }
+}
+
 <div
   className="c0"
   id="test-hero"

--- a/src/features/rewards/hero/index.tsx
+++ b/src/features/rewards/hero/index.tsx
@@ -7,15 +7,19 @@ import { StyledHero } from './style'
 
 export interface Props {
   id?: string
+  isMobile?: boolean
   children?: React.ReactNode
 }
 
 export default class Hero extends React.PureComponent<Props, {}> {
   render () {
-    const { id, children } = this.props
+    const { id, isMobile, children } = this.props
 
     return (
-      <StyledHero id={id}>
+      <StyledHero
+        id={id}
+        isMobile={isMobile}
+      >
         {children}
       </StyledHero>
     )

--- a/src/features/rewards/hero/style.ts
+++ b/src/features/rewards/hero/style.ts
@@ -1,12 +1,20 @@
 import styled from 'styled-components'
 
-export const StyledHero = styled<{}, 'div'>('div')`
+interface StyleProps {
+  isMobile?: boolean
+}
+
+export const StyledHero = styled<StyleProps, 'div'>('div')`
   text-align: center;
   min-height: 610px;
   padding: 60px 0 25px 0;
-  border-top-left-radius: 35px;
-  border-top-right-radius: 35px;
+  border-top-left-radius: ${p => p.isMobile ? 0 : 35}px;
+  border-top-right-radius: ${p => p.isMobile ? 0 : 35}px;
   background: linear-gradient(#392DD1, #8C41DE);
   border-bottom-left-radius: 150% 120px;
   border-bottom-right-radius: 150% 120px;
+
+  @media (max-width: 475px) {
+    padding-top: 35px;
+  }
 `

--- a/src/features/rewards/welcomePage/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/welcomePage/__snapshots__/spec.tsx.snap
@@ -348,7 +348,6 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
   color: #5BC4FE;
   font-weight: 500;
   text-align: center;
-  line-height: 28px;
   margin: 18px 0 7px;
 }
 
@@ -401,10 +400,23 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
   overflow: hidden;
 }
 
+@media (max-width:475px) {
+  .c5 {
+    padding-top: 35px;
+  }
+}
+
 @media (max-width:640px) {
   .c33 {
     grid-gap: 20px;
     grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width:410px) {
+  .c17 {
+    margin: 40px 20px;
+    max-width: unset;
   }
 }
 
@@ -426,6 +438,24 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
 @media (max-width:980px) {
   .c3 {
     background: #F8FAFF;
+  }
+}
+
+@media (max-width:460px) {
+  .c6 {
+    height: 100px;
+  }
+}
+
+@media (max-width:360px) {
+  .c9 {
+    font-size: 36px;
+  }
+}
+
+@media (max-width:360px) {
+  .c13 {
+    font-size: 22px;
   }
 }
 

--- a/src/features/rewards/welcomePage/index.tsx
+++ b/src/features/rewards/welcomePage/index.tsx
@@ -55,11 +55,13 @@ export interface Props {
 }
 
 class WelcomePage extends React.PureComponent<Props, {}> {
+  private isTouchScreen: boolean
   private centerTextSection: HTMLDivElement | null
 
   constructor (props: Props) {
     super(props)
     this.centerTextSection = null
+    this.isTouchScreen = 'ontouchstart' in document.documentElement
   }
 
   scrollToCenter = () => {
@@ -86,7 +88,10 @@ class WelcomePage extends React.PureComponent<Props, {}> {
 
   hero () {
     return (
-      <Hero id={'rewards-hero'}>
+      <Hero
+        id={'rewards-hero'}
+        isMobile={this.isTouchScreen}
+      >
         <StyledSection>
           <StyledBatLogo>
             <BatColorIcon />
@@ -212,13 +217,11 @@ class WelcomePage extends React.PureComponent<Props, {}> {
     ]
   }
 
-  render () {
-    const { id, onReTry } = this.props
-
+  get welcomePageContent () {
     return (
-      <SettingsPage id={id}>
+      <>
         {
-          onReTry
+          this.props.onReTry
           ? <StyledAlert>
             <Alert type={'error'}>
               <StyledAlertContent>
@@ -229,7 +232,7 @@ class WelcomePage extends React.PureComponent<Props, {}> {
                     level={'primary'}
                     type={'accent'}
                     text={getLocale('walletFailedButton')}
-                    onClick={onReTry}
+                    onClick={this.props.onReTry}
                   />
               </StyledAlertContent>
             </Alert>
@@ -255,6 +258,21 @@ class WelcomePage extends React.PureComponent<Props, {}> {
             </StyledTakeActionContent>
           </StyledCenterSection>
         </StyledBackground>
+      </>
+    )
+  }
+
+  render () {
+    const { id } = this.props
+
+    // We don't need the SettingsPage wrapper on touchscreen devices
+    if (this.isTouchScreen) {
+      return this.welcomePageContent
+    }
+
+    return (
+      <SettingsPage id={id}>
+        {this.welcomePageContent}
       </SettingsPage>
     )
   }

--- a/src/features/rewards/welcomePage/style.ts
+++ b/src/features/rewards/welcomePage/style.ts
@@ -10,6 +10,11 @@ const centerBackground = require('./assets/centerTextBackground.svg')
 export const StyledOptInSection = styled<{}, 'section'>('section')`
   margin: 40px auto;
   max-width: 303px;
+
+  @media (max-width: 410px) {
+    margin: 40px 20px;
+    max-width: unset;
+  }
 `
 
 export const StyledOptInSecond = styled<{}, 'section'>('section')`
@@ -71,6 +76,10 @@ export const StyledBackground = styled<{}, 'div'>('div')`
 export const StyledBatLogo = styled<{}, 'div'>('div')`
   margin: 5px auto 0;
   height: 152px;
+
+  @media (max-width: 460px) {
+    height: 100px;
+  }
 `
 
 export const StyledRewardsTitle = styled(Heading)`
@@ -78,6 +87,10 @@ export const StyledRewardsTitle = styled(Heading)`
   color: #FFF;
   display: inline-block;
   margin: 17px 0 4px;
+
+  @media (max-width: 360px) {
+    font-size: 36px;
+  }
 `
 
 export const StyledActionTitle = styled(Heading)`
@@ -100,8 +113,11 @@ export const StyledSubTitle = styled(Heading)`
   color: #5BC4FE;
   font-weight: 500;
   text-align: center;
-  line-height: 28px;
   margin: 18px 0 7px;
+
+  @media (max-width: 360px) {
+    font-size: 22px;
+  }
 `
 
 export const StyledTrademark = styled<{}, 'span'>('span')`


### PR DESCRIPTION
This includes a view small design tweaks targeted for mobile per design review:

1. Reduces the font size of the hero header/subtitle on smaller devices
2. On touchscreen devices removes the outer settings page wrapper/desktop header
3. Reduces hero padding for smaller devices