### PR TITLE
Adding Grant claim/Wallet summary feature to Mobile Settings page

### DIFF
--- a/src/features/rewards/grantClaim/index.tsx
+++ b/src/features/rewards/grantClaim/index.tsx
@@ -9,15 +9,19 @@ import { GiftIcon } from '../../../components/icons'
 
 export interface Props {
   id?: string
+  isMobile?: boolean
   onClaim: () => void
 }
 
 export default class GrantClaim extends React.PureComponent<Props, {}> {
   render () {
-    const { id, onClaim } = this.props
+    const { id, isMobile, onClaim } = this.props
 
     return (
-      <StyledWrapper id={id}>
+      <StyledWrapper
+        id={id}
+        isMobile={isMobile}
+      >
         <StyledIcon>
           <GiftIcon />
         </StyledIcon>

--- a/src/features/rewards/grantClaim/style.ts
+++ b/src/features/rewards/grantClaim/style.ts
@@ -4,7 +4,11 @@
 
 import styled from 'styled-components'
 
-export const StyledWrapper = styled<{}, 'div'>('div')`
+interface StyleProps {
+  isMobile?: boolean
+}
+
+export const StyledWrapper = styled<StyleProps, 'div'>('div')`
   display: flex;
   align-items: center;
   flex-wrap: nowrap;
@@ -13,7 +17,7 @@ export const StyledWrapper = styled<{}, 'div'>('div')`
   background-color: #fff;
   overflow: hidden;
   padding-left: 20px;
-  margin-bottom: 19px;
+  margin-bottom: ${p => p.isMobile ? 15 : 19}px;
   width: 100%;
 `
 

--- a/src/features/rewards/grantWrapper/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/grantWrapper/__snapshots__/spec.tsx.snap
@@ -26,7 +26,8 @@ exports[`Grant wrapper tests basic tests matches the snapshot 1`] = `
   width: 100%;
   padding: 0 52px 20px;
   border-radius: 6px;
-  height: 100%;
+  height: auto;
+  overflow-y: hidden;
 }
 
 .c3 {

--- a/src/features/rewards/grantWrapper/index.tsx
+++ b/src/features/rewards/grantWrapper/index.tsx
@@ -12,16 +12,20 @@ export interface Props {
   id?: string
   onClose: () => void
   title: string
+  fullScreen?: boolean
   text: React.ReactNode
   children: React.ReactNode
 }
 
 export default class GrantWrapper extends React.PureComponent<Props, {}> {
   render () {
-    const { id, onClose, title, text, children } = this.props
+    const { id, fullScreen, onClose, title, text, children } = this.props
 
     return (
-      <StyledWrapper id={id}>
+      <StyledWrapper
+        id={id}
+        fullScreen={fullScreen}
+      >
         <StyledClose onClick={onClose}>
           <CloseStrokeIcon />
         </StyledClose>

--- a/src/features/rewards/grantWrapper/style.ts
+++ b/src/features/rewards/grantWrapper/style.ts
@@ -4,8 +4,12 @@
 
 import styled from 'styled-components'
 
-export const StyledWrapper = styled<{}, 'div'>('div')`
-  position: absolute;
+interface StyleProps {
+  fullScreen?: boolean
+}
+
+export const StyledWrapper = styled<StyleProps, 'div'>('div')`
+  position: ${p => p.fullScreen ? 'fixed' : 'absolute'};
   top: 0;
   left: 0;
   z-index: 6;
@@ -14,12 +18,13 @@ export const StyledWrapper = styled<{}, 'div'>('div')`
   align-content: flex-start;
   flex-wrap: wrap;
   font-family: Poppins, sans-serif;
-  background-color: rgba(255, 255, 255, 0.95);
+  background-color: ${p => p.fullScreen ? '#fff' : 'rgba(255, 255, 255, 0.95)'};
   overflow: hidden;
   width: 100%;
   padding: 0 52px 20px;
   border-radius: 6px;
-  height: 100%;
+  height: ${p => p.fullScreen ? '100%' : 'auto'};
+  overflow-y: ${p => p.fullScreen ? 'scroll' : 'hidden'};
 `
 
 export const StyledHeader = styled<{}, 'div'>('div')`

--- a/src/features/rewards/mobile/walletInfoHeader/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/mobile/walletInfoHeader/__snapshots__/spec.tsx.snap
@@ -62,6 +62,12 @@ exports[`WalletInfoHeader tests basic tests matches the snapshot 1`] = `
   letter-spacing: 0px;
 }
 
+@media (max-width:360px) {
+  .c2 {
+    font-size: 14px;
+  }
+}
+
 <div
   className="c0"
   id="info-header"

--- a/src/features/rewards/mobile/walletInfoHeader/index.tsx
+++ b/src/features/rewards/mobile/walletInfoHeader/index.tsx
@@ -18,15 +18,19 @@ export interface Props {
   id?: string
   balance: string
   converted?: string
+  onClick: () => void
 }
 
 export default class WalletInfoHeader extends React.PureComponent<Props, {}> {
 
   render () {
-    const { id, balance, converted } = this.props
+    const { id, balance, converted, onClick } = this.props
 
     return (
-      <StyledWrapper id={id}>
+      <StyledWrapper
+        id={id}
+        onClick={onClick}
+      >
         <StyledHeader>
           <StyledTitle>{getLocale('yourWallet')}</StyledTitle>
             <StyledBalance>

--- a/src/features/rewards/mobile/walletInfoHeader/style.ts
+++ b/src/features/rewards/mobile/walletInfoHeader/style.ts
@@ -28,6 +28,10 @@ export const StyledTitle = styled<{}, 'div'>('div')`
   line-height: 1.38;
   letter-spacing: -0.2px;
   color: rgba(255, 255, 255, 0.65);
+
+  @media (max-width: 360px) {
+    font-size: 14px;
+  }
 `
 
 export const StyledBalance = styled<{}, 'div'>('div')`

--- a/src/features/rewards/modalAddFunds/index.tsx
+++ b/src/features/rewards/modalAddFunds/index.tsx
@@ -36,6 +36,7 @@ export interface Address {
 export interface Props {
   onClose: () => void
   id?: string
+  isMobile?: boolean
   addresses: Address[]
 }
 
@@ -65,11 +66,14 @@ export default class ModalAddFunds extends React.PureComponent<Props, State> {
   }
 
   getAddress = (address: Address) => {
-
+    const { isMobile } = this.props
     const current = address.type === this.state.current
 
     return (
-      <StyledAddress key={`address-${address.type}`}>
+      <StyledAddress
+        isMobile={!!isMobile}
+        key={`address-${address.type}`}
+      >
         <StyledHeader>
           <StyledLogo>
             {icons[address.type]}

--- a/src/features/rewards/modalAddFunds/style.ts
+++ b/src/features/rewards/modalAddFunds/style.ts
@@ -6,6 +6,10 @@ import styled from 'styled-components'
 import Button, { Props as ButtonProps } from '../../../components/buttonsIndicators/button'
 import { ComponentType } from 'react'
 
+interface StyleProps {
+  isMobile: boolean
+}
+
 export const StyledWrapper = styled<{}, 'div'>('div')`
   font-family: Poppins, sans-serif;
 `
@@ -33,11 +37,11 @@ export const StyledAddresses = styled<{}, 'div'>('div') `
   align-items: stretch;
 `
 
-export const StyledAddress = styled<{}, 'div'>('div') `
-  flex-basis: 50%;
+export const StyledAddress = styled<StyleProps, 'div'>('div') `
+  flex-basis: ${p => p.isMobile ? 100 : 50}%;
   flex-shrink: 0;
   flex-grow: 0;
-  width: 50%;
+  width: ${p => p.isMobile ? 100 : 50}%;
   box-sizing: border-box;
   padding: 0 15px 26px;
 `

--- a/src/features/rewards/walletWrapper/index.tsx
+++ b/src/features/rewards/walletWrapper/index.tsx
@@ -94,6 +94,7 @@ export interface Props {
   alert?: AlertWallet | null
   id?: string
   gradientTop?: string
+  isMobile?: boolean
   notification?: Notification
 }
 
@@ -229,7 +230,8 @@ export default class WalletWrapper extends React.PureComponent<Props, State> {
       onSettingsClick,
       alert,
       gradientTop,
-      notification
+      notification,
+      isMobile
     } = this.props
 
     const hasGrants = this.hasGrants(grants)
@@ -239,6 +241,7 @@ export default class WalletWrapper extends React.PureComponent<Props, State> {
         <StyledWrapper
           id={id}
           compact={compact}
+          isMobile={isMobile}
           notification={notification}
         >
           <StyledHeader>

--- a/src/features/rewards/walletWrapper/style.ts
+++ b/src/features/rewards/walletWrapper/style.ts
@@ -10,6 +10,7 @@ interface StyledProps {
   contentPadding?: boolean,
   compact?: boolean,
   background?: string,
+  isMobile?: boolean,
   notification?: Notification | undefined
 }
 
@@ -50,7 +51,7 @@ export const StyledWrapper = styled<StyledProps, 'div'>('div')`
   overflow: hidden;
   box-shadow: 0 0 8px 0 rgba(99, 105, 110, 0.12);
   font-family: Poppins, sans-serif;
-  width: 373px;
+  width: ${p => p.isMobile ? '100%' : '373px'};
   background: ${p => wrapperBackgroundRules(p.notification)};
   min-height: ${p => p.compact ? 'unset' : '715px'};
   border-radius: ${p => p.compact ? '0' : '6px'};
@@ -135,7 +136,7 @@ export const StyledCopyImage = styled<{}, 'span'>('span')`
 
 export const StyledIconAction = styled<{}, 'button'>('button')`
   position: absolute;
-  top: 21px;
+  top: 15px;
   right: 21px;
   background: none;
   padding: 0;

--- a/stories/features/rewards/settingsMobile/grantMobile.tsx
+++ b/stories/features/rewards/settingsMobile/grantMobile.tsx
@@ -44,7 +44,10 @@ class GrantMobile extends React.Component<{}, State > {
       <>
         {
           this.state.grantShow
-          ? <GrantClaim onClaim={this.onClaim}/>
+          ? <GrantClaim
+            isMobile={true}
+            onClaim={this.onClaim}
+          />
           : null
         }
         {

--- a/stories/features/rewards/settingsMobile/grantMobile.tsx
+++ b/stories/features/rewards/settingsMobile/grantMobile.tsx
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as React from 'react'
+
+// Components
+import {
+  GrantClaim,
+  GrantComplete,
+  GrantWrapper
+} from '../../../../src/features/rewards'
+
+type Step = '' | 'complete'
+
+interface State {
+  grantShow: boolean
+  grantStep: Step
+}
+
+class GrantMobile extends React.Component<{}, State > {
+  constructor (props: {}) {
+    super(props)
+    this.state = {
+      grantShow: true,
+      grantStep: ''
+    }
+  }
+
+  onGrantHide = () => {
+    this.setState({ grantStep: '' })
+  }
+
+  onClaim = () => {
+    this.setState({ grantStep: 'complete' })
+  }
+
+  onComplete = () => {
+    this.setState({ grantStep: '', grantShow: false })
+  }
+
+  render () {
+    return (
+      <>
+        {
+          this.state.grantShow
+          ? <GrantClaim onClaim={this.onClaim}/>
+          : null
+        }
+        {
+          this.state.grantStep === 'complete'
+          ? <GrantWrapper
+            fullScreen={true}
+            onClose={this.onGrantHide}
+            title={'It’s your lucky day!'}
+            text={'Your token grant is on its way.'}
+          >
+            <GrantComplete onClose={this.onComplete} amount={'30.0'} date={'8/15/2018'} />
+          </GrantWrapper>
+          : null
+        }
+      </>
+    )
+  }
+}
+
+export default GrantMobile

--- a/stories/features/rewards/settingsMobile/mobileWalletPanel.tsx
+++ b/stories/features/rewards/settingsMobile/mobileWalletPanel.tsx
@@ -1,0 +1,137 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as React from 'react'
+import { boolean, object } from '@storybook/addon-knobs'
+
+import { WalletSummary, WalletWrapper } from '../../../../src/features/rewards'
+import { StyledWalletClose, StyledWalletOverlay, StyledWalletWrapper } from './style'
+import { CloseStrokeIcon, WalletAddIcon } from '../../../../src/components/icons'
+import ModalAddFunds, { Address } from '../../../../src/features/rewards/modalAddFunds'
+
+interface State {
+  addFundsShown?: boolean
+}
+
+interface Props {
+  visible?: boolean
+  toggleAction: () => void
+}
+
+const doNothing = () => {
+  console.log('nothing')
+}
+
+const notImplemented = () => {
+  console.log('view not implemented')
+}
+
+class MobileWalletPanel extends React.Component<Props, State> {
+  constructor (props: Props) {
+    super(props)
+
+    this.state = {
+      addFundsShown: false
+    }
+  }
+
+  toggleAddFunds = () => {
+    this.setState({ addFundsShown: !this.state.addFundsShown })
+  }
+
+  get walletAddresses (): Address[] {
+    return [
+      {
+        type: 'BTC',
+        address: '17fBi3kyqUd2jjPDSi8ArBbMWso16qmxW5',
+        qr: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAALkAAAC5CAAAAABRxsGAAAABz0lEQVR42u3cQY7DIAwF0Nz/0u1uVgP5hqYV8Fh1lFF4qVRjbNrrteq4yMnJycnJycnJycnJyXeRX/ejfcO/q6X/q89GTn62PJiz+Wdz9v/uXJqNnJy8/blvRo9mLGg+V302cnLyAXm6jAfBiZyc/EF5kJ+n9yMnJ5/Pz4OZSnvu7+0syMmXlwdr+Qdffbk6R06+sjxu1YRpeD9f+EWHi5x8ZXnwuW8+QwAs1a3JycnjwJEm34OtpFJuT05+tjyIMkHtqm6bjy3k5MfI09JT0A5KL8THqcjJT5WnnddHwkqAJicnj/fDaa82zRzmO7nk5MfI+4SgxBz0eftv22hsISffVx6Ei9J0/TJYvQBNTk6ebJSDq6Os6bMW5OT7ypO1NzwhVdpf99MMcnLyuPP68HONrv7k5GfJSy2d+nY7jUHk5OQ38mDOWokqXP3nYws5+W7ydPRjUD3vLu25ycmPlV/3I60zB6cp+q/mO1zk5FvK04hSP9FU+qrAJ6tz5OS7yeuHK9IE4aoMcnLyUflgzCgVvsnJyedjS1oQSytq89U5cvLN5fWraWoerPTk5OTzv4FWf8z0uR6szpGTryxfYpCTk5OTk5OTk5OTk5OvON4QJEO8FpFK4QAAAABJRU5ErkJggg=='
+      },
+      {
+        type: 'ETH',
+        address: '0xF10bfc0EB8Fcfd1240a5BB97C3e5a7752cD1C388',
+        qr: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAM0AAADNCAAAAAA+16u1AAACPklEQVR42u3bwU7DMBAE0P7/T8ONA1LcGXsTFfRyKpQ2+3IY2bvm9fWfrhcNDQ0NDQ0NDQ0NDQ0NDc2p5vX+6m7y84lfry6/ebMCGhqaSU1QW/CJX2+kT6KvgIaG5h7NZd5UubQu6/KbgwpoaGg+QNNn2iWYhobm72rSzwZxRkND81GatGex+bG14eHdGg0NTd/rvPnVw51bGhqajTHj8iZplWlL5O4pLg0NTbC7qIruextBqtLQ0DyiqQaYl8LL363Dbv04hlY2NDQ0qSYoK4ikILqC5c15ptHQ0FSa4E792HJzhHo08aChoTmeEfQ3Duae/RLqqMtBQ0NzsrIJGhebtfWtz/P9DQ0NTZVpgStY43T9yrBDQkND84imGmX2rYn10qiKMxoamnFNuhxJrZvnH9MGBw0NzbgmbWakZaVReHIaioaGZkhTRVe1sgkmKNXGh4aG5h7NzHQybWb0OXfU66ShoakmHsGwI9gMBXk4s8ahoaEZ0lSdy+CU08k/TQ0lNA0NzaYmaFqmG5X+EY13bmloaI4zbXOP0g871o9tKKFpaGjSTAuOL6Y90X7Pk8YZDQ3NpCZuKoQHodYxlbY5aWhontO83l/rP+6LmTlQTUNDM6lJkyzY7lSLpODJ0tDQPKfZLDCIs2p4Mtm5paGhuVmzLjrY5KQNTxoamo/XHGfaxgiGhoZmWpO+GxxcSmNq8+ADDQ3NuCbdbAQ/phuV4I9v7NzS0ND8g4uGhoaGhoaGhoaGhoaGhqa5vgFTleQ0sHcoKgAAAABJRU5ErkJggg=='
+      },
+      {
+        type: 'BAT',
+        address: '0xF10bfc0EB8Fcfd1240a5BB97C3e5a7752cD1C388',
+        qr: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAM0AAADNCAAAAAA+16u1AAACPklEQVR42u3bwU7DMBAE0P7/T8ONA1LcGXsTFfRyKpQ2+3IY2bvm9fWfrhcNDQ0NDQ0NDQ0NDQ0NDc2p5vX+6m7y84lfry6/ebMCGhqaSU1QW/CJX2+kT6KvgIaG5h7NZd5UubQu6/KbgwpoaGg+QNNn2iWYhobm72rSzwZxRkND81GatGex+bG14eHdGg0NTd/rvPnVw51bGhqajTHj8iZplWlL5O4pLg0NTbC7qIruextBqtLQ0DyiqQaYl8LL363Dbv04hlY2NDQ0qSYoK4ikILqC5c15ptHQ0FSa4E792HJzhHo08aChoTmeEfQ3Duae/RLqqMtBQ0NzsrIJGhebtfWtz/P9DQ0NTZVpgStY43T9yrBDQkND84imGmX2rYn10qiKMxoamnFNuhxJrZvnH9MGBw0NzbgmbWakZaVReHIaioaGZkhTRVe1sgkmKNXGh4aG5h7NzHQybWb0OXfU66ShoakmHsGwI9gMBXk4s8ahoaEZ0lSdy+CU08k/TQ0lNA0NzaYmaFqmG5X+EY13bmloaI4zbXOP0g871o9tKKFpaGjSTAuOL6Y90X7Pk8YZDQ3NpCZuKoQHodYxlbY5aWhontO83l/rP+6LmTlQTUNDM6lJkyzY7lSLpODJ0tDQPKfZLDCIs2p4Mtm5paGhuVmzLjrY5KQNTxoamo/XHGfaxgiGhoZmWpO+GxxcSmNq8+ADDQ3NuCbdbAQ/phuV4I9v7NzS0ND8g4uGhoaGhoaGhoaGhoaGhqa5vgFTleQ0sHcoKgAAAABJRU5ErkJggg=='
+      },
+      {
+        type: 'LTC',
+        address: 'Le8aswhmGJjn9jP5teEWdyJARak4xU8sCn',
+        qr: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAM0AAADNCAAAAAA+16u1AAACOUlEQVR42u3bQXLDIAwF0Nz/0u0FYvKFBNN0Hit7mtq8LDTwRV4//2m8aGhoaGhoaGhoaGhoaGhouprX57H+8LvnvbstPXT9DhoamnHNc+F4fNZyWmvX0AxoaGimNe/qyONf16UrqILBO2hoaL5Is4YESx4aGpov0pRK13prQ0ND86c0gbX0zvX0g/nS0NDc0wRJ4+Gry8ktDQ3NRptxL7ksTfBeF5eGhibYXQSR5mPtS/dBHTANDc2kJkguSwUrtbYaojQ0NEc06e1mSVq7gmCUhobmoCbIHIPOZsnVWd7Q0NCMa9Iwo9TZ3MgwwwyEhoZmXBN0MR+vgmVL50QEDQ3NPU2w4Ci1LUvdzsmUg4aGpt73TE8lBWlIqYhNdjxoaGg6fc/A1d6ZpKcjk7fR0NAMatJ5pM3PYPsU/Ec/s6GhoUlXNmlforRsqR9yCLqiNDQ045pSWekccCr1VvtZJw0NTSfrDEpXUBnTk9HpXouGhua0Zv3AzW7n+iMH+540NDT1rHN97LkejsRLlM9nrmloaO5pSpFmWr+Cn1qkSy0aGprLmtJpqHVcEViH9jc0NDQlTTo2s41SejF5oouGhqaTdaYlKbgKdk6lM9I0NDRnNEElS0OP9DtJ26o0NDT3NEG96fQvgv3Smd0aDQ3NoGZzPVPqc9DQ0PxlTTC3/orlc8BBQ0NzRpMGmeltUMTW3ywNDc09TZBPBH3PemFrlVEaGpoZzdcOGhoaGhoaGhoaGhoaGhqayvgFbnvHJxkVZlQAAAAASUVORK5CYII='
+      }
+    ]
+  }
+
+  render () {
+    const { visible, toggleAction } = this.props
+
+    if (!visible) {
+      return null
+    }
+
+    return (
+      <>
+        <StyledWalletOverlay>
+          <StyledWalletClose>
+            <CloseStrokeIcon onClick={toggleAction}/>
+          </StyledWalletClose>
+          <StyledWalletWrapper>
+            <WalletWrapper
+              balance={'30.0'}
+              converted={'7.00 USD'}
+              actions={[
+                {
+                  name: 'Add funds',
+                  action: this.toggleAddFunds,
+                  icon: <WalletAddIcon />
+                }
+              ]}
+              compact={true}
+              isMobile={true}
+              onSettingsClick={notImplemented}
+              onActivityClick={doNothing}
+              showSecActions={true}
+              grants={object('Claimed grants', [
+                {
+                  tokens: '8.0',
+                  expireDate: '7/15/2018'
+                },
+                {
+                  tokens: '10.0',
+                  expireDate: '9/10/2018'
+                },
+                {
+                  tokens: '10.0',
+                  expireDate: '10/10/2018'
+                }
+              ])}
+              connectedWallet={boolean('Connected wallet', false)}
+            >
+              <WalletSummary
+                report={{
+                  grant: { tokens: '10.0', converted: '0.25' },
+                  ads: { tokens: '10.0', converted: '0.25' },
+                  deposit: { tokens: '10.0', converted: '0.25' },
+                  contribute: { tokens: '10.0', converted: '0.25' },
+                  donation: { tokens: '2.0', converted: '0.25' },
+                  tips: { tokens: '19.0', converted: '5.25' }
+                }}
+                onActivity={doNothing}
+              />
+            </WalletWrapper>
+          </StyledWalletWrapper>
+          {
+            this.state.addFundsShown
+            ? <ModalAddFunds isMobile={true} onClose={this.toggleAddFunds} addresses={this.walletAddresses} />
+            : null
+          }
+        </StyledWalletOverlay>
+      </>
+    )
+  }
+}
+
+export default MobileWalletPanel

--- a/stories/features/rewards/settingsMobile/settingsMobile.tsx
+++ b/stories/features/rewards/settingsMobile/settingsMobile.tsx
@@ -5,6 +5,7 @@
 import * as React from 'react'
 
 // Components
+import GrantMobile from './grantMobile'
 import AdsBoxMobile from './adsBoxMobile'
 import ContributeBoxMobile from './contributeBoxMobile'
 import DonationsBoxMobile from './donationsBoxMobile'
@@ -60,6 +61,7 @@ class SettingsMobile extends React.PureComponent<{}, State> {
             </StyledDisabledContent>
           : null
         }
+        <GrantMobile />
         <WalletInfoHeader
           balance={'30.0'}
           id={'mobile-wallet'}

--- a/stories/features/rewards/settingsMobile/settingsMobile.tsx
+++ b/stories/features/rewards/settingsMobile/settingsMobile.tsx
@@ -9,6 +9,7 @@ import GrantMobile from './grantMobile'
 import AdsBoxMobile from './adsBoxMobile'
 import ContributeBoxMobile from './contributeBoxMobile'
 import DonationsBoxMobile from './donationsBoxMobile'
+import MobileWalletPanel from './mobileWalletPanel'
 import { StyledDisabledContent, StyledHeading, StyledText } from './style'
 import {
   MainToggleMobile,
@@ -25,18 +26,24 @@ import locale from './fakeLocale'
 
 interface State {
   mainToggle: boolean
+  walletShown: boolean
 }
 
 class SettingsMobile extends React.PureComponent<{}, State> {
   constructor (props: {}) {
     super(props)
     this.state = {
-      mainToggle: true
+      mainToggle: true,
+      walletShown: false
     }
   }
 
   onMainToggle = () => {
     this.setState({ mainToggle: !this.state.mainToggle })
+  }
+
+  onToggleWallet = () => {
+    this.setState({ walletShown: !this.state.walletShown })
   }
 
   render () {
@@ -65,7 +72,8 @@ class SettingsMobile extends React.PureComponent<{}, State> {
         <WalletInfoHeader
           balance={'30.0'}
           id={'mobile-wallet'}
-          converted={'163230.50 USD'}
+          onClick={this.onToggleWallet}
+          converted={'7.00 USD'}
         />
         <AdsBoxMobile
           rewardsEnabled={this.state.mainToggle}
@@ -75,6 +83,10 @@ class SettingsMobile extends React.PureComponent<{}, State> {
         />
         <DonationsBoxMobile
           rewardsEnabled={this.state.mainToggle}
+        />
+        <MobileWalletPanel
+          toggleAction={this.onToggleWallet}
+          visible={this.state.walletShown}
         />
       </SettingsPageMobile>
     )

--- a/stories/features/rewards/settingsMobile/style.ts
+++ b/stories/features/rewards/settingsMobile/style.ts
@@ -67,3 +67,31 @@ export const StyledSupportSites = styled<{}, 'div'>('div')`
     font-size: 14px;
   }
 `
+
+export const StyledWalletOverlay = styled<{}, 'div'>('div')`
+  display: flex;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: ${p => p.theme.color.modalOverlayBackground};
+  align-items: center;
+  z-index: 999;
+  justify-content: center;
+`
+
+export const StyledWalletWrapper = styled<{}, 'div'>('div')`
+  height: 90vh;
+  overflow-y: scroll;
+  width: 90%;
+  margin-top: 40px;
+`
+
+export const StyledWalletClose = styled<{}, 'div'>('div')`
+  top: 15px;
+  right: 15px;
+  position: fixed;
+  color: ${p => p.theme.color.subtleExclude};
+  width: 25px;
+`

--- a/stories/features/rewards/wallet.tsx
+++ b/stories/features/rewards/wallet.tsx
@@ -163,6 +163,7 @@ storiesOf('Feature Components/Rewards/Wallet/Mobile', module)
         <div style={{ width: '100%', position: 'absolute', top: '30%' }}>
           <WalletInfoHeader
             id={'info-header'}
+            onClick={doNothing}
             balance={text('Balance', '30.0')}
             converted={text('Converted', '163230.50 USD')}
           />


### PR DESCRIPTION
Storybook: https://brave-ui-fgfdeeypjd.now.sh

Unclaimed:
<img width="408" alt="screen shot 2018-10-18 at 1 39 37 am" src="https://user-images.githubusercontent.com/8732757/47141985-bc2f7200-d276-11e8-9b58-0a6e174b1673.png">

Claim Promp:
<img width="426" alt="screen shot 2018-10-17 at 10 14 03 pm" src="https://user-images.githubusercontent.com/8732757/47132679-0a824800-d25a-11e8-9689-91af2b69f6f0.png">

Mobile Wallet Summary: (After clicking on walletInfoHeader)
<img width="413" alt="screen shot 2018-10-18 at 1 30 43 am" src="https://user-images.githubusercontent.com/8732757/47141439-86d65480-d275-11e8-8894-04c67e0c59a8.png">

Add Funds view:
<img width="407" alt="screen shot 2018-10-18 at 1 31 33 am" src="https://user-images.githubusercontent.com/8732757/47141470-9c4b7e80-d275-11e8-9de7-c3297f6b44f5.png">
