### PR TITLE
Fixes long publisher titles breaking out of wallet panel

### DIFF
--- a/src/features/rewards/profile/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/profile/__snapshots__/spec.tsx.snap
@@ -53,12 +53,12 @@ exports[`Profile tests basic tests matches the snapshot 1`] = `
 }
 
 .c4 {
+  width: 280px;
   margin-top: 0;
   margin-left: 10px;
 }
 
 .c5 {
-  white-space: nowrap;
   font-family: Muli,sans-serif;
   font-size: 14px;
   font-weight: 600;

--- a/src/features/rewards/profile/style.ts
+++ b/src/features/rewards/profile/style.ts
@@ -57,13 +57,12 @@ export const StyledContent = styled<Partial<Props>, 'div'>('div')`
 `
 
 export const StyledTitleWrap = styled<Partial<Props>, 'div'>('div')`
+  width: 280px;
   margin-top: ${p => p.type === 'big' ? '2px' : 0};
   margin-left: ${p => p.type !== 'big' ? '10px' : 0};
 `
 
 export const StyledTitle = styled<Partial<Props>, 'span'>('span')`
-  white-space: nowrap;
-
   ${p => p.type === 'big'
     ? css`
       font-size: 18px;
@@ -89,7 +88,6 @@ export const StyledTitle = styled<Partial<Props>, 'span'>('span')`
 `
 
 export const StyledProvider = styled<Partial<Props>, 'span'>('span')`
-  white-space: nowrap;
   padding-left: 5px;
 
   ${p => p.type === 'big'

--- a/src/features/rewards/walletPanel/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/walletPanel/__snapshots__/spec.tsx.snap
@@ -266,12 +266,12 @@ exports[`WalletPanel tests basic tests matches the snapshot 1`] = `
 }
 
 .c6 {
+  width: 280px;
   margin-top: 2px;
   margin-left: 0;
 }
 
 .c7 {
-  white-space: nowrap;
   font-size: 18px;
   font-weight: 500;
   line-height: 1.22;


### PR DESCRIPTION
Fixes: #224 

Fix pictured:
<img width="396" alt="screen shot 2018-10-18 at 8 44 15 pm" src="https://user-images.githubusercontent.com/8732757/47196685-9a85c780-d316-11e8-8d34-0e1b843900f1.png">

<img width="391" alt="screen shot 2018-10-18 at 8 37 11 pm" src="https://user-images.githubusercontent.com/8732757/47196661-85109d80-d316-11e8-9f3a-734c7e932807.png">

<img width="391" alt="screen shot 2018-10-18 at 8 36 46 pm" src="https://user-images.githubusercontent.com/8732757/47196663-8641ca80-d316-11e8-8447-3f87981c8412.png">
