### PR TITLE
Enforces 1024px min-width for settingsPage

### DIFF
--- a/src/features/rewards/settingsPage/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/settingsPage/__snapshots__/spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`SettingsPage tests basic tests matches the snapshot 1`] = `
 .c0 {
   background: #f2f4f7;
   min-height: 100vh;
-  width: 100%;
+  min-width: 1024px;
   font-family: "Poppins",sans-serif;
 }
 

--- a/src/features/rewards/settingsPage/style.ts
+++ b/src/features/rewards/settingsPage/style.ts
@@ -7,7 +7,7 @@ import styled from 'styled-components'
 export const StyledWrapper = styled<{}, 'div'>('div')`
   background: #f2f4f7;
   min-height: 100vh;
-  width: 100%;
+  min-width: 1024px;
   font-family: "Poppins", sans-serif
 `
 

--- a/src/features/rewards/welcomePage/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/welcomePage/__snapshots__/spec.tsx.snap
@@ -15,7 +15,7 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
 .c0 {
   background: #f2f4f7;
   min-height: 100vh;
-  width: 100%;
+  min-width: 1024px;
   font-family: "Poppins",sans-serif;
 }
 


### PR DESCRIPTION
Fixes #230 

Related: https://github.com/brave/brave-browser/issues/1556

Before:
<img width="669" alt="screen shot 2018-10-22 at 6 15 35 pm" src="https://user-images.githubusercontent.com/8732757/47328621-8e577e00-d626-11e8-989f-284185b34ba1.png">

After: 
<img width="690" alt="screen shot 2018-10-22 at 6 15 57 pm" src="https://user-images.githubusercontent.com/8732757/47328631-96172280-d626-11e8-8333-a04ff6a65573.png">
