### PR TITLE
Fixes tooltip persistence issue for site exclude

### DIFF
--- a/src/features/rewards/tooltip/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/tooltip/__snapshots__/spec.tsx.snap
@@ -41,11 +41,13 @@ exports[`Tooltip tests basic tests matches the snapshot 1`] = `
   border-color: transparent transparent #0C0D21 transparent;
 }
 
+.c4 {
+  cursor: pointer;
+}
+
 <div
   className="c0"
   id="tooltip"
-  onMouseEnter={[Function]}
-  onMouseLeave={[Function]}
 >
   <div
     className="c1"
@@ -57,5 +59,10 @@ exports[`Tooltip tests basic tests matches the snapshot 1`] = `
       className="c3"
     />
   </div>
+  <div
+    className="c4"
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  />
 </div>
 `;

--- a/src/features/rewards/tooltip/index.tsx
+++ b/src/features/rewards/tooltip/index.tsx
@@ -8,7 +8,8 @@ import {
   StyledWrapper,
   StyledTooltip,
   StyledTooltipText,
-  StyledPointer
+  StyledPointer,
+  StyledChildWrapper
 } from './style'
 
 export interface Props {
@@ -42,18 +43,19 @@ export default class Tooltip extends React.PureComponent<Props, State> {
     const { id, content, children } = this.props
 
     return (
-      <StyledWrapper
-        id={id}
-        onMouseEnter={this.onMouseEnter}
-        onMouseLeave={this.onMouseLeave}
-      >
+      <StyledWrapper id={id}>
         <StyledTooltip displayed={this.state.displayed}>
           <StyledPointer/>
           <StyledTooltipText>
             {content}
           </StyledTooltipText>
         </StyledTooltip>
-        {children}
+        <StyledChildWrapper
+          onMouseEnter={this.onMouseEnter}
+          onMouseLeave={this.onMouseLeave}
+        >
+          {children}
+        </StyledChildWrapper>
       </StyledWrapper>
     )
   }

--- a/src/features/rewards/tooltip/style.ts
+++ b/src/features/rewards/tooltip/style.ts
@@ -45,3 +45,7 @@ export const StyledPointer = styled<{}, 'div'>('div')`
   border-width: 0 7px 8px 7px;
   border-color: transparent transparent #0C0D21 transparent;
 `
+
+export const StyledChildWrapper = styled<{}, 'div'>('div')`
+  cursor: pointer;
+`

--- a/stories/features/rewards/settings/contributeBox.tsx
+++ b/stories/features/rewards/settings/contributeBox.tsx
@@ -216,6 +216,7 @@ class ContributeBox extends React.Component<{}, State> {
           rows={this.contributeRows}
           allSites={false}
           numSites={55}
+          showRemove={true}
           onShowAll={this.onContributeModalOpen.bind(self)}
           headerColor={true}
         >


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/1850

Basically, the mouse intent area was too large, making it possible through quick movements to persist the tooltip, and block site exclude actions.

This reduces the mouse area to just the `children` of `<Tooltip>`, leaving functionality as expected and this bug not reproducible. 