### PR TITLE
Adding RestoreSites component

### DIFF
--- a/src/features/rewards/index.ts
+++ b/src/features/rewards/index.ts
@@ -25,6 +25,7 @@ import ModalDonation from './modalDonation'
 import NextContribution from './nextContribution'
 import PanelWelcome from './panelWelcome'
 import Profile from './profile'
+import RestoreSites from './restoreSites'
 import SettingsPage from './settingsPage'
 import SiteBanner from './siteBanner'
 import Tab from './tab'
@@ -68,6 +69,7 @@ export {
   NextContribution,
   PanelWelcome,
   Profile,
+  RestoreSites,
   SettingsPage,
   SiteBanner,
   Tab,

--- a/src/features/rewards/modalContribute/index.tsx
+++ b/src/features/rewards/modalContribute/index.tsx
@@ -7,10 +7,9 @@ import {
   StyledWrapper,
   StyledTitle,
   StyledContent,
-  StyledNum,
-  StyledRestore,
-  StyledExcludedText
+  StyledNum
 } from './style'
+import RestoreSites from '../restoreSites'
 import Modal from '../../../components/popupModals/modal/index'
 import TableContribute, { DetailRow } from '../tableContribute/index'
 import { getLocale } from '../../../helpers'
@@ -32,14 +31,6 @@ export default class ModalContribute extends React.PureComponent<Props, {}> {
     ]
   }
 
-  getRestoreText () {
-    return `(${getLocale('restoreAll')})`
-  }
-
-  getExclusionText (numSites: number) {
-    return `${getLocale('excludedSitesText')} ${numSites}`
-  }
-
   render () {
     const { id, onClose, onRestore, rows, numExcludedSites } = this.props
     const numSites = rows && rows.length || 0
@@ -53,12 +44,10 @@ export default class ModalContribute extends React.PureComponent<Props, {}> {
           </StyledContent>
           {
             numExcludedSites && numExcludedSites > 0
-            ? <StyledExcludedText>
-                {this.getExclusionText(numExcludedSites)}
-                <StyledRestore onClick={onRestore}>
-                  {this.getRestoreText()}
-                </StyledRestore>
-              </StyledExcludedText>
+            ? <RestoreSites
+                onRestore={onRestore}
+                numExcludedSites={numExcludedSites}
+            />
             : null
           }
           <TableContribute

--- a/src/features/rewards/modalContribute/style.ts
+++ b/src/features/rewards/modalContribute/style.ts
@@ -21,27 +21,7 @@ export const StyledContent = styled<{}, 'div'>('div')`
   margin-bottom: 33px;
 `
 
-export const StyledExcludedText = styled<{}, 'div'>('div')`
-  color: #4B4C5C;
-  font-size: 14px;
-  font-weight: 300;
-  text-align: left;
-  letter-spacing: 0;
-  margin-top: -20px;
-  margin-bottom: 33px;
-`
-
 export const StyledNum = styled<{}, 'span'>('span')`
   font-weight: 500;
   color: #0c0d21;
-`
-
-export const StyledRestore = styled<{}, 'a'>('a')`
-  color: #696fdc;
-  display: inline-block;
-  font-size: 13px;
-  font-weight: normal;
-  letter-spacing: 0;
-  cursor: pointer;
-  margin-left: 8px;
 `

--- a/src/features/rewards/restoreSites/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/restoreSites/__snapshots__/spec.tsx.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RestoreSites tests basic tests matches the snapshot 1`] = `
+.c0 {
+  color: #4B4C5C;
+  font-size: 14px;
+  font-weight: 300;
+  text-align: left;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  margin-top: -20px;
+  margin-bottom: 33px;
+}
+
+.c1 {
+  color: #696fdc;
+  display: inline-block;
+  font-size: 13px;
+  font-weight: normal;
+  -webkit-letter-spacing: 0;
+  -moz-letter-spacing: 0;
+  -ms-letter-spacing: 0;
+  letter-spacing: 0;
+  cursor: pointer;
+  margin-left: 8px;
+}
+
+<div
+  className="c0"
+>
+  MISSING: excludedSitesText undefined
+  <a
+    className="c1"
+  >
+    (MISSING: restoreAll)
+  </a>
+</div>
+`;

--- a/src/features/rewards/restoreSites/index.tsx
+++ b/src/features/rewards/restoreSites/index.tsx
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this file,
+* You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+import * as React from 'react'
+import { getLocale } from '../../../helpers'
+import {
+  StyledExcludedText,
+  StyledRestore
+} from './style'
+
+export interface Props {
+  numExcludedSites: number
+  onRestore?: () => void
+}
+
+export default class RestoreSites extends React.PureComponent<Props, {}> {
+  getRestoreText () {
+    return `(${getLocale('restoreAll')})`
+  }
+
+  getExclusionText (numSites: number) {
+    return `${getLocale('excludedSitesText')} ${numSites}`
+  }
+
+  render () {
+    const { numExcludedSites, onRestore } = this.props
+
+    return (
+      <StyledExcludedText>
+        {this.getExclusionText(numExcludedSites)}
+        <StyledRestore onClick={onRestore}>
+          {this.getRestoreText()}
+        </StyledRestore>
+      </StyledExcludedText>
+    )
+  }
+}

--- a/src/features/rewards/restoreSites/spec.tsx
+++ b/src/features/rewards/restoreSites/spec.tsx
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this file,
+* You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+import * as React from 'react'
+import { shallow } from 'enzyme'
+import { create } from 'react-test-renderer'
+import RestoreSites from './index'
+import { TestThemeProvider } from '../../../theme'
+
+describe('RestoreSites tests', () => {
+  const baseComponent = (props?: object) => <TestThemeProvider><RestoreSites id='restoresites' {...props} /></TestThemeProvider>
+
+  describe('basic tests', () => {
+    it('matches the snapshot', () => {
+      const component = baseComponent()
+      const tree = create(component).toJSON()
+      expect(tree).toMatchSnapshot()
+    })
+
+    it('renders the component', () => {
+      const wrapper = shallow(baseComponent())
+      const assertion = wrapper.find('#restoresites').length
+      expect(assertion).toBe(1)
+    })
+  })
+})

--- a/src/features/rewards/restoreSites/style.ts
+++ b/src/features/rewards/restoreSites/style.ts
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this file,
+* You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+import styled from 'styled-components'
+
+export const StyledExcludedText = styled<{}, 'div'>('div')`
+  color: #4B4C5C;
+  font-size: 14px;
+  font-weight: 300;
+  text-align: left;
+  letter-spacing: 0;
+  margin-top: -20px;
+  margin-bottom: 33px;
+`
+
+export const StyledRestore = styled<{}, 'a'>('a')`
+  color: #696fdc;
+  display: inline-block;
+  font-size: 13px;
+  font-weight: normal;
+  letter-spacing: 0;
+  cursor: pointer;
+  margin-left: 8px;
+`

--- a/src/features/rewards/tableContribute/index.tsx
+++ b/src/features/rewards/tableContribute/index.tsx
@@ -10,12 +10,13 @@ import {
   StyledTHOther,
   StyledTHLast,
   StyledToggleWrap,
-  StyledLink
+  StyledLink,
+  StyledRestoreSites
 } from './style'
 import Table, { Row } from '../../../components/dataTables/table'
 import Profile, { Provider } from '../profile'
 import { getLocale } from '../../../helpers'
-import { Tokens, Tooltip } from '../'
+import { RestoreSites, Tokens, Tooltip } from '../'
 import { CloseStrokeIcon } from '../../../components/icons'
 
 interface ProfileCell {
@@ -44,6 +45,8 @@ export interface Props {
   numSites?: number
   allSites?: boolean
   onShowAll?: () => void
+  onRestore?: () => void
+  numExcludedSites?: number
 }
 
 export default class TableContribute extends React.PureComponent<Props, {}> {
@@ -168,7 +171,7 @@ export default class TableContribute extends React.PureComponent<Props, {}> {
   }
 
   render () {
-    const { id, header, children, rows, allSites, onShowAll } = this.props
+    const { id, header, children, rows, allSites, onShowAll, onRestore, numExcludedSites } = this.props
     const numSites = this.props.numSites || 0
 
     return (
@@ -183,6 +186,16 @@ export default class TableContribute extends React.PureComponent<Props, {}> {
           ? <StyledToggleWrap>
               <StyledToggle onClick={onShowAll}>{getLocale('seeAllSites', { numSites })}</StyledToggle>
             </StyledToggleWrap>
+          : null
+        }
+        {
+          allSites && numExcludedSites && numExcludedSites > 0
+          ? <StyledRestoreSites>
+              <RestoreSites
+                onRestore={onRestore}
+                numExcludedSites={numExcludedSites}
+              />
+            </StyledRestoreSites>
           : null
         }
       </div>

--- a/src/features/rewards/tableContribute/style.ts
+++ b/src/features/rewards/tableContribute/style.ts
@@ -49,3 +49,8 @@ export const StyledToggle = styled<{}, 'button'>('button')`
 export const StyledLink = styled<{}, 'a'>('a')`
   text-decoration: none;
 `
+
+export const StyledRestoreSites = styled<{}, 'div'>('div')`
+  padding-top: 15px;
+  margin-bottom: -20px;
+`

--- a/stories/assets/locale.ts
+++ b/stories/assets/locale.ts
@@ -54,7 +54,7 @@ const locale: Record<string, string> = {
   earningsAds: 'Earnings from Brave Ads',
   enableTips: 'Enable Tips',
   excludeSite: 'Exclude this site',
-  excludedSitesText: 'Total number of sites you excluded from Auto-Contribute:',
+  excludedSitesText: 'Sites excluded from Auto-Contributions:',
   expiresOn: 'expires on',
   for: 'for',
   grants: 'Grants',

--- a/stories/features/rewards/settings/contributeBox.tsx
+++ b/stories/features/rewards/settings/contributeBox.tsx
@@ -187,6 +187,7 @@ class ContributeBox extends React.Component<{}, State> {
           this.state.modalContribute
             ? <ModalContribute
               onRestore={doNothing}
+              numExcludedSites={100}
               rows={this.contributeRows}
               onClose={this.onContributeModalClose.bind(self)}
             />
@@ -217,6 +218,8 @@ class ContributeBox extends React.Component<{}, State> {
           allSites={false}
           numSites={55}
           showRemove={true}
+          onRestore={doNothing}
+          numExcludedSites={100}
           onShowAll={this.onContributeModalOpen.bind(self)}
           headerColor={true}
         >


### PR DESCRIPTION
Related: https://github.com/brave/brave-browser/issues/1883

Since code would have to be duplicated to include this in `TableContribute`, I refactored the restore sites prompt in to its own component.

Pictured here on the `TableContribute` component under `Box`:

<img width="622" alt="screen shot 2018-11-05 at 5 31 19 pm" src="https://user-images.githubusercontent.com/8732757/48035573-df389d80-e121-11e8-9896-19b6018f2520.png">

Note ^^ as this prompt is hidden on the outer view when "Show All" is present, you won't see it like this in the storybook. You may view the component in the contribute modal by clicking "Show All" in the event of 5 or few sites, this will be visible on the outer view.
