### PR TITLE
Reduces alert close icon size

### DIFF
--- a/src/features/rewards/walletWrapper/style.ts
+++ b/src/features/rewards/walletWrapper/style.ts
@@ -239,8 +239,8 @@ export const StyledAlertClose = styled<{}, 'button'>('button')`
   top: 11px;
   right: 11px;
   cursor: pointer;
-  width: 30px;
-  height: 30px;
+  width: 15px;
+  height: 15px;
   color: #B8B9C4;
 `
 


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/9574457/48702630-aa344c80-ebf1-11e8-81a5-59c11c9bb3a8.png)

after:
![image](https://user-images.githubusercontent.com/9574457/48702621-a3a5d500-ebf1-11e8-9db0-aa5cfa851a8c.png)
