### PR TITLE
Changing monthlyAmount prop to string

### DIFF
--- a/src/features/rewards/walletPanel/index.tsx
+++ b/src/features/rewards/walletPanel/index.tsx
@@ -48,7 +48,7 @@ export interface Props {
   attentionScore?: string | null
   tipsEnabled: boolean
   includeInAuto: boolean
-  monthlyAmount: number
+  monthlyAmount: string
   donationAmounts?: Token[]
   toggleTips?: boolean
   donationAction: () => void
@@ -76,7 +76,7 @@ export default class WalletPanel extends React.PureComponent<Props, {}> {
 
   donationDropDown () {
     const { donationAmounts } = this.props
-    const monthlyAmount = this.props.monthlyAmount || 5
+    const monthlyAmount = this.props.monthlyAmount || '5.0'
 
     if (!donationAmounts) {
       return null
@@ -87,7 +87,7 @@ export default class WalletPanel extends React.PureComponent<Props, {}> {
         <Select
           floating={true}
           showAllContents={true}
-          value={monthlyAmount.toString()}
+          value={monthlyAmount}
           onChange={this.props.onAmountChange}
         >
           {donationAmounts.map((token: Token, index: number) => {

--- a/stories/features/rewards/concepts.tsx
+++ b/stories/features/rewards/concepts.tsx
@@ -250,7 +250,7 @@ storiesOf('Feature Components/Rewards/Concepts/Desktop', module)
                 platform={'youtube'}
                 publisherImg={bartBaker}
                 publisherName={'Bart Baker'}
-                monthlyAmount={10}
+                monthlyAmount={'5.0'}
                 isVerified={true}
                 tipsEnabled={boolean('Tips enabled', store.state.tipsEnabled)}
                 includeInAuto={boolean('Tips enabled', store.state.includeInAuto)}

--- a/stories/features/rewards/wallet.tsx
+++ b/stories/features/rewards/wallet.tsx
@@ -4,7 +4,7 @@
 
 import * as React from 'react'
 import { storiesOf } from '@storybook/react'
-import { withKnobs, object, select, number, text, boolean } from '@storybook/addon-knobs'
+import { withKnobs, object, select, text, boolean } from '@storybook/addon-knobs'
 // @ts-ignore
 import centered from '@storybook/addon-centered/dist'
 
@@ -105,7 +105,7 @@ storiesOf('Feature Components/Rewards/Wallet/Desktop', module)
           platform={select('Provider', { youtube: 'YouTube', twitter: 'Twitter', twitch: 'Twitch' }, 'youtube')}
           publisherImg={bartBaker}
           publisherName={'Bart Baker'}
-          monthlyAmount={number('Amount', 10)}
+          monthlyAmount={'10.0'}
           isVerified={boolean('Verified', true)}
           tipsEnabled={boolean('Tips Enabled', true)}
           includeInAuto={boolean('Include in monthly', true)}


### PR DESCRIPTION
Fixes: #291 
To be used by: https://github.com/brave/brave-core/pull/957

Before (`monthlyAmount={10}`)
<img width="424" alt="screen shot 2018-11-26 at 7 55 47 pm" src="https://user-images.githubusercontent.com/8732757/49055642-89ea2c00-f1b5-11e8-956f-fcf312743ccb.png">

After (`monthlyAmount={'10.0'}`)
<img width="456" alt="screen shot 2018-11-26 at 7 55 51 pm" src="https://user-images.githubusercontent.com/8732757/49055625-7c34a680-f1b5-11e8-8ff7-c6c25cb771ef.png">