### PR TITLE
Adds data-test-id to RewardsButton

### DIFF
--- a/src/features/rewards/welcomePage/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/welcomePage/__snapshots__/spec.tsx.snap
@@ -477,6 +477,7 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
           >
             <button
               className="c18"
+              data-test-id="optInAction"
               onClick={[Function]}
               type="opt-in"
             >

--- a/src/features/rewards/welcomePage/index.tsx
+++ b/src/features/rewards/welcomePage/index.tsx
@@ -114,12 +114,14 @@ class WelcomePage extends React.PureComponent<Props, {}> {
             ? <RewardsButton
               type={'opt-in'}
               disabled={true}
+              testId={'optInAction'}
               text={getLocale('braveRewardsCreatingText')}
               icon={<LoaderIcon/>}
             />
             : <RewardsButton
               type={'opt-in'}
               onClick={this.optInAction}
+              testId={'optInAction'}
               text={getLocale('braveRewardsOptInText')}
             />
           }


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/2277