### PR TITLE
Uses string type for amount/tokens

### DIFF
--- a/src/features/rewards/amount/index.tsx
+++ b/src/features/rewards/amount/index.tsx
@@ -10,7 +10,7 @@ import { BatColorIcon } from '../../../components/icons'
 export interface Props {
   amount: string
   converted: string
-  onSelect: (amount: number) => void
+  onSelect: (amount: string) => void
   id?: string
   selected?: boolean
   type?: 'big' | 'small'

--- a/src/features/rewards/donate/index.tsx
+++ b/src/features/rewards/donate/index.tsx
@@ -33,9 +33,9 @@ export interface Props {
   title: string
   balance: number
   donationAmounts: Donation[]
-  currentAmount: number
-  onDonate: (amount: number) => void
-  onAmountSelection?: (tokens: number) => void
+  currentAmount: string
+  onDonate: (amount: string) => void
+  onAmountSelection?: (tokens: string) => void
   id?: string
   donateType: DonateType
   children?: React.ReactNode
@@ -74,17 +74,17 @@ export default class Donate extends React.PureComponent<Props, State> {
     }
   }
 
-  validateAmount (balance: number, tokens?: number) {
+  validateAmount (balance: number, tokens?: string) {
     if (tokens === undefined) {
       tokens = this.props.currentAmount
     }
 
-    const valid = tokens > balance
+    const valid = parseInt(tokens, 10) > balance
     this.setState({ missingFunds: valid })
     return valid
   }
 
-  onAmountChange = (tokens: number) => {
+  onAmountChange = (tokens: string) => {
     this.validateAmount(this.props.balance, tokens)
 
     if (this.props.onAmountSelection) {
@@ -94,7 +94,7 @@ export default class Donate extends React.PureComponent<Props, State> {
 
   render () {
     const { id, donationAmounts, actionText, children, title, currentAmount, donateType, isMobile } = this.props
-    const disabled = currentAmount === 0
+    const disabled = parseInt(currentAmount, 10) === 0
 
     return (
       <StyledWrapper donateType={donateType} disabled={disabled} isMobile={isMobile}>

--- a/src/features/rewards/siteBanner/index.tsx
+++ b/src/features/rewards/siteBanner/index.tsx
@@ -46,9 +46,9 @@ export type Donation = {tokens: string, converted: string, selected?: boolean}
 
 export interface Props {
   balance: string
-  currentAmount: number
+  currentAmount: string
   donationAmounts: Donation[]
-  onAmountSelection: (tokens: number) => void
+  onAmountSelection: (tokens: string) => void
   id?: string
   title?: string
   name?: string
@@ -59,7 +59,7 @@ export interface Props {
   provider?: SocialType
   recurringDonation?: boolean
   children?: React.ReactNode
-  onDonate: (amount: number, monthly: boolean) => void
+  onDonate: (amount: string, monthly: boolean) => void
   onClose?: () => void
   isMobile?: boolean
   logoBgColor?: CSS.Color
@@ -166,7 +166,7 @@ export default class SiteBanner extends React.PureComponent<Props, State> {
     this.setState({ monthly: selected })
   }
 
-  onDonate = (amount: number) => {
+  onDonate = (amount: string) => {
     if (this.props.onDonate) {
       this.props.onDonate(amount, this.state.monthly)
     }

--- a/src/features/rewards/tip/index.tsx
+++ b/src/features/rewards/tip/index.tsx
@@ -22,11 +22,11 @@ export interface Props {
   allow: boolean
   provider: string
   balance: string
-  currentAmount: number
+  currentAmount: string
   donationAmounts: Donation[]
-  onAmountSelection?: (tokens: number) => void
+  onAmountSelection?: (tokens: string) => void
   onAllow: (allow: boolean) => void
-  onDonate: (amount: number, allow: boolean) => void
+  onDonate: (amount: string, allow: boolean) => void
   onClose: () => void
   id?: string
   title?: string
@@ -37,7 +37,7 @@ export default class Tip extends React.PureComponent<Props, {}> {
     title: ''
   }
 
-  onDonate = (amount: number) => {
+  onDonate = (amount: string) => {
     if (this.props.onDonate) {
       this.props.onDonate(amount, this.props.allow)
     }
@@ -49,7 +49,7 @@ export default class Tip extends React.PureComponent<Props, {}> {
     }
   }
 
-  onAmountChange = (tokens: number) => {
+  onAmountChange = (tokens: string) => {
     if (this.props.onAmountSelection) {
       this.props.onAmountSelection(tokens)
     }

--- a/stories/features/rewards/concepts.tsx
+++ b/stories/features/rewards/concepts.tsx
@@ -39,12 +39,12 @@ storiesOf('Feature Components/Rewards/Concepts/Desktop', module)
       optInAction={dummyOptInAction}
     />
   ))
-  .add('Site Banner', withState({ donationAmounts, currentAmount: 5, showBanner: true }, (store) => {
+  .add('Site Banner', withState({ donationAmounts, currentAmount: '5.0', showBanner: true }, (store) => {
     const onDonate = () => {
       console.log('onDonate')
     }
 
-    const onAmountSelection = (tokens: number) => {
+    const onAmountSelection = (tokens: string) => {
       store.set({ currentAmount: tokens })
     }
 
@@ -98,7 +98,7 @@ storiesOf('Feature Components/Rewards/Concepts/Desktop', module)
       </div>
     )
   }))
-  .add('Tip', withState({ donationAmounts, currentAmount: 5, allow: false }, (store) => {
+  .add('Tip', withState({ donationAmounts, currentAmount: '5.0', allow: false }, (store) => {
     const onDonate = () => {
       console.log('onDonate')
     }
@@ -111,7 +111,7 @@ storiesOf('Feature Components/Rewards/Concepts/Desktop', module)
       store.set({ allow })
     }
 
-    const onAmountSelection = (tokens: number) => {
+    const onAmountSelection = (tokens: string) => {
       store.set({ currentAmount: tokens })
     }
 
@@ -305,12 +305,12 @@ storiesOf('Feature Components/Rewards/Concepts/Mobile', module)
     />
   ))
   .add('Settings', () => <SettingsMobile />)
-  .add('Site Banner', withState({ donationAmounts, currentAmount: 5, showBanner: true }, (store) => {
+  .add('Site Banner', withState({ donationAmounts, currentAmount: '5.0', showBanner: true }, (store) => {
     const onDonate = () => {
       console.log('onDonate')
     }
 
-    const onAmountSelection = (tokens: number) => {
+    const onAmountSelection = (tokens: string) => {
       store.set({ currentAmount: tokens })
     }
 

--- a/stories/features/rewards/other.tsx
+++ b/stories/features/rewards/other.tsx
@@ -109,12 +109,12 @@ storiesOf('Feature Components/Rewards/Other/Desktop', module)
       </div>
     )
   }))
-  .add('Donate', withState({ donationAmounts, currentAmount: 5 }, (store) => {
+  .add('Donate', withState({ donationAmounts, currentAmount: '5.0' }, (store) => {
     const onDonate = () => {
       console.log('onDonate')
     }
 
-    const onAmountSelection = (tokens: number) => {
+    const onAmountSelection = (tokens: string) => {
       store.set({ currentAmount: tokens })
     }
 
@@ -128,7 +128,7 @@ storiesOf('Feature Components/Rewards/Other/Desktop', module)
         title={'Donation amount'}
         actionText={text('Action text', 'Send my Donation')}
         onAmountSelection={onAmountSelection}
-        currentAmount={number('Current amount', store.state.currentAmount)}
+        currentAmount={text('Current amount', store.state.currentAmount)}
       />
     </div>
     )


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-ui/issues/298

This is what involved in fixing the integration test error in the issue. It seems that there was further inconsistency in amount typing even after the work done https://github.com/brave/brave-ui/pull/194

Everything works in the UI as far as I have tested, (Balance calculation works, and expected error will come up if you select a token amount that exceeds your wallet balance