### PR TITLE
Add support for insufficientFunds notification

### DIFF
--- a/src/features/rewards/walletWrapper/index.tsx
+++ b/src/features/rewards/walletWrapper/index.tsx
@@ -69,7 +69,7 @@ export interface ActionWallet {
   action: () => void
 }
 
-export type NotificationType = 'ads' | 'contribute' | 'grant' | 'error' | ''
+export type NotificationType = 'ads' | 'contribute' | 'grant' | 'insufficientFunds' | 'error' | ''
 
 export interface Notification {
   id: string
@@ -172,6 +172,9 @@ export default class WalletWrapper extends React.PureComponent<Props, State> {
       case 'grant':
         icon = giftIconUrl
         break
+      case 'insufficientFunds':
+        icon = megaphoneIconUrl
+        break
       default:
         icon = ''
         break
@@ -198,6 +201,9 @@ export default class WalletWrapper extends React.PureComponent<Props, State> {
         break
       case 'grant':
         typeText = getLocale('tokenGrant')
+        break
+      case 'insufficientFunds':
+        typeText = getLocale('insufficientFunds')
         break
       default:
         typeText = ''


### PR DESCRIPTION
This is associated with brave/brave-browser#1479.

Adds support for "insufficient funds" notifications in Rewards, which is sent when the current balance is insufficient to make new contributions.