### PR TITLE
Fixing rewards toggle for long translations

### DIFF
--- a/src/features/rewards/mobile/mainToggleMobile/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/mobile/mainToggleMobile/__snapshots__/spec.tsx.snap
@@ -51,17 +51,10 @@ exports[`MainToggleMobile tests basic tests matches the snapshot 1`] = `
 }
 
 .c6 {
-  padding: 0px 15px;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   height: 66px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-top: -3px;
+  position: fixed;
+  right: 15px;
+  top: 18px;
 }
 
 .c4 {
@@ -72,8 +65,8 @@ exports[`MainToggleMobile tests basic tests matches the snapshot 1`] = `
   -moz-letter-spacing: 0.12px;
   -ms-letter-spacing: 0.12px;
   letter-spacing: 0.12px;
-  line-height: 44px;
   margin-bottom: -23px;
+  line-height: 44px;
 }
 
 .c5 {
@@ -158,11 +151,19 @@ exports[`MainToggleMobile tests basic tests matches the snapshot 1`] = `
   fill: currentColor;
 }
 
-@media (max-width:355px) {
-  .c6 {
-    width: 55px;
-    position: relative;
-    right: 45px;
+@media (max-width:375px) {
+  .c4 {
+    max-width: 250px;
+    word-wrap: break-word;
+    display: block;
+    line-height: 20px;
+    margin-top: -12px;
+  }
+}
+
+@media (max-width:375px) {
+  .c5 {
+    top: -2px;
   }
 }
 

--- a/src/features/rewards/mobile/mainToggleMobile/style.ts
+++ b/src/features/rewards/mobile/mainToggleMobile/style.ts
@@ -30,17 +30,10 @@ export const StyledLeft = styled<{}, 'div'>('div')`
 `
 
 export const StyledRight = styled<{}, 'div'>('div')`
-  padding: 0px 15px;
-  display: flex;
   height: 66px;
-  align-items: center;
-  margin-top: -3px;
-
-  @media (max-width: 355px) {
-    width: 55px;
-    position: relative;
-    right: 45px;
-  }
+  position: fixed;
+  right: 15px;
+  top: 18px;
 `
 
 export const StyledTitle = styled<{}, 'div'>('div')`
@@ -48,8 +41,16 @@ export const StyledTitle = styled<{}, 'div'>('div')`
   font-size: 22px;
   font-weight: 500;
   letter-spacing: 0.12px;
-  line-height: 44px;
   margin-bottom: -23px;
+  line-height: 44px;
+
+  @media (max-width: 375px) {
+    max-width: 250px;
+    word-wrap: break-word;
+    display: block;
+    line-height: 20px;
+    margin-top: -12px;
+  }
 `
 
 export const StyledTM = styled<{}, 'span'>('span')`
@@ -61,6 +62,10 @@ export const StyledTM = styled<{}, 'span'>('span')`
   position: relative;
   top: -13px;
   vertical-align: text-top;
+
+  @media (max-width: 375px) {
+    top: -2px;
+  }
 `
 
 export const StyledLogoWrapper = styled<{}, 'div'>('div')`


### PR DESCRIPTION
Related: https://github.com/brave/browser-android-tabs/issues/914

Fix at small (320px) viewport: (Text wrapping was agreed upon)
<img width="338" alt="screen shot 2018-12-10 at 4 47 41 pm" src="https://user-images.githubusercontent.com/8732757/49769139-4c4ccf00-fc9c-11e8-8d38-10d635ee1a0b.png">

Fix at larger, but still slim 375px viewport:
<img width="388" alt="screen shot 2018-12-10 at 4 47 55 pm" src="https://user-images.githubusercontent.com/8732757/49769157-5a9aeb00-fc9c-11e8-92cf-843ef5cf0a0d.png">

