### PR TITLE
Add support for backupWallet notification

### DIFF
--- a/src/features/rewards/walletWrapper/index.tsx
+++ b/src/features/rewards/walletWrapper/index.tsx
@@ -69,7 +69,7 @@ export interface ActionWallet {
   action: () => void
 }
 
-export type NotificationType = 'ads' | 'contribute' | 'grant' | 'insufficientFunds' | 'error' | ''
+export type NotificationType = 'ads' | 'backupWallet' | 'contribute' | 'grant' | 'insufficientFunds' | 'error' | ''
 
 export interface Notification {
   id: string
@@ -164,6 +164,7 @@ export default class WalletWrapper extends React.PureComponent<Props, State> {
 
     switch (notification.type) {
       case 'ads':
+      case 'backupWallet':
         icon = megaphoneIconUrl
         break
       case 'contribute':
@@ -195,6 +196,9 @@ export default class WalletWrapper extends React.PureComponent<Props, State> {
     switch (notification.type) {
       case 'ads':
         typeText = getLocale('braveAdsTitle')
+        break
+      case 'backupWallet':
+        typeText = getLocale('backupWalletTitle')
         break
       case 'contribute':
         typeText = getLocale('braveContributeTitle')


### PR DESCRIPTION
This is associated with brave/brave-browser#1164.

Adds support for "backup wallet" notifications in Rewards, which is sent when the user needs to backup their wallet.