### PR TITLE
Remaining NTP Updates

### DIFF
--- a/src/features/newTab/stats/style.ts
+++ b/src/features/newTab/stats/style.ts
@@ -5,7 +5,8 @@
 import styled from '../../../theme'
 
 export const StyledStatsItemContainer = styled<{}, 'ul'>('ul')`
-  display: block;
+  display: flex;
+  flex-wrap: wrap;
   font-weight: 400;
   margin: 0;
   padding: 0;
@@ -21,53 +22,44 @@ export const StyledStatsItemContainer = styled<{}, 'ul'>('ul')`
 `
 
 export const StyledStatsItem = styled<{}, 'li'>('li')`
-  vertical-align: middle;
   list-style-type: none;
   font-size: inherit;
   font-family: inherit;
 
   &:first-child {
-    color: rgb(243, 144, 48);
+    color: #FB542B;
   }
   &:nth-child(2) {
-    color: rgb(254, 82, 29);
+    color: #B02FFB;
   }
   &:nth-child(3) {
-    color: rgb(7, 150, 250);
+    color: #4C54D2;
   }
   &:last-child {
-    color: rgb(153, 153, 153);
+    color: #FFF;
   }
 `
 
 export const StyledStatsItemCounter = styled<{}, 'span'>('span')`
   color: inherit;
   font-family: ${p => p.theme.fontFamily.heading};
-  font-size: 44px;
+  font-size: 46px;
   font-weight: 400;
-  line-height: 53px;
-  width: 7ch;
-  letter-spacing: -0.4px;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
 `
 
 export const StyledStatsItemText = styled<{}, 'span'>('span')`
-  color: rgb(153, 153, 153);
+  color: #FFF;
   font-size: 20px;
+  margin-left: 4px;
   font-family: ${p => p.theme.fontFamily.heading};
-  line-height: 24px;
-  margin-left: 3px;
-  display: inline;
-  letter-spacing: 0;
 `
 
 export const StyledStatsItemDescription = styled<{}, 'div'>('div')`
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 400;
-  color: rgb(255, 255, 255);
-  line-height: 24px;
-  margin-left: 3px;
+  color: #FFF;
   font-family: ${p => p.theme.fontFamily.heading};
 `

--- a/src/old/clock/style.ts
+++ b/src/old/clock/style.ts
@@ -12,7 +12,6 @@ const StyledClock = styled.div`
   line-height: 1;
   user-select: none;
   display: flex;
-  cursor: default;
   -webkit-font-smoothing: antialiased;
   font-family: inherit;
 ` as any
@@ -20,7 +19,7 @@ const StyledClock = styled.div`
 const StyledTime = styled.span`
   box-sizing: border-box;
   letter-spacing: 0;
-  font-size: 75px;
+  font-size: 90px;
   font-weight: 200;
   color: inherit;
   font-family: inherit;
@@ -28,16 +27,7 @@ const StyledTime = styled.span`
 ` as any
 
 const StyledPeriod = styled.span`
-  box-sizing: border-box;
-  color: inherit;
-  font-family: inherit;
-  display: inline-block;
-  font-size: 20px;
-  letter-spacing: -0.2px;
-  font-weight: 200;
-  margin-top: 8px;
-  margin-left: 3px;
-  vertical-align: top;
+  display: none;
 ` as any
 
 const StyledTimeSeparator = styled.span`


### PR DESCRIPTION
Remaining minor style tweaks still located in Brave UI related to https://github.com/brave/brave-core/pull/1091. 

- color updates to a more current brand palette
- enlarged the clock typeface
- omitted the time period
- general padding tweaks

<img width="1032" alt="screen shot 2018-12-14 at 4 19 03 pm" src="https://user-images.githubusercontent.com/29072694/50036478-00609980-ffbe-11e8-8511-ce0f9bda7316.png">
