### PR TITLE
Fixing bottom padding issue with WalletSummarySlider

### DIFF
--- a/src/features/rewards/walletSummarySlider/style.ts
+++ b/src/features/rewards/walletSummarySlider/style.ts
@@ -28,7 +28,8 @@ export const StyledToggleWrapper = styled<StyleProps, 'div'>('div')`
   max-height: 56px;
   padding: ${p => p.show ? '18px 30px 20px 30px' : '20px'};
   top: ${p => p.show ? 'unset' : '12px'};
-  position: ${p => p.show ? 'static' : 'absolute'};
+  position: absolute;
+  bottom: ${p => p.show ? '0px' : 'unset'};
   background: ${p => p.show ? '#E9EBFF' : 'inherit'};
 ` as any
 

--- a/stories/features/rewards/concepts.tsx
+++ b/stories/features/rewards/concepts.tsx
@@ -331,7 +331,7 @@ storiesOf('Feature Components/Rewards/Concepts/Desktop', module)
             >
               <WalletPanel
                 id={'wallet-panel'}
-                toggleTips={true}
+                toggleTips={boolean('Toggle tips', true)}
                 platform={'youtube'}
                 publisherImg={bartBaker}
                 publisherName={'Bart Baker'}


### PR DESCRIPTION
Related: https://github.com/brave/brave-browser/issues/2590

## Changes
Ensures that rewards summary slider stays at the bottom of the panel with no padding, whether or not the ToggleTips component is present.

## Test plan
View the Wallet Panel concept in the provided storybook link, disable/enable ToggleTips and ensure that no padding exists at the bottom in either case.

##### Link / storybook path to visual changes
https://brave-ui-32480gqva.now.sh

Fix pictured in b-c (with previous patch removed)
<img width="430" alt="screen shot 2018-12-16 at 11 28 54 pm" src="https://user-images.githubusercontent.com/8732757/50070211-70237f80-018a-11e9-9a83-e135d53fd26c.png">

- 
<!-- can be localhost storybook or `now` deployment -->

## Integration
- [ ] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [x] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [x] Will you create brave-core PR to update to this commit after it is merged?
  - [x] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
