### PR TITLE
Captcha wrong position status fix

### DIFF
--- a/src/features/rewards/walletWrapper/index.tsx
+++ b/src/features/rewards/walletWrapper/index.tsx
@@ -167,12 +167,13 @@ export default class WalletWrapper extends React.PureComponent<Props, State> {
 
   grantCaptcha = () => {
     const { grant } = this.props
+    const status = grant && grant.status
 
     if (!grant || !grant.promotionId) {
       return
     }
 
-    if (grant && grant.status === 'grantGone') {
+    if (status === 'grantGone') {
       return (
         <GrantWrapper
           onClose={this.onFinish}
@@ -188,7 +189,7 @@ export default class WalletWrapper extends React.PureComponent<Props, State> {
       )
     }
 
-    if (grant && grant.status === 'generalError') {
+    if (status === 'generalError') {
       return (
         <GrantWrapper
           onClose={this.onGrantHide}


### PR DESCRIPTION
Fixes the issue mentioned here: https://github.com/brave/brave-core/pull/1092#pullrequestreview-185459333

## Changes
Simply captures the grant status in a variable called `status`

Problem was that `status` here was undefined: https://github.com/brave/brave-ui/blob/master/src/features/rewards/walletWrapper/index.tsx#L215

## Test plan


##### Link / storybook path to visual changes
- 
<!-- can be localhost storybook or `now` deployment -->

## Integration
- [ ] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [ ] Does this contain changes to src/features for brave-core?
  - [x] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [ ] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
