### PR TITLE
Fixing grant claim icon alignment

### DIFF
--- a/src/features/rewards/grantWrapper/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/grantWrapper/__snapshots__/spec.tsx.snap
@@ -51,15 +51,15 @@ exports[`Grant wrapper tests basic tests matches the snapshot 1`] = `
 
 .c1 {
   top: 16px;
-  right: 16px;
+  right: 15px;
   position: absolute;
   padding: 0;
   border: none;
   background: none;
   cursor: pointer;
   color: #B8B9C4;
-  width: 20px;
-  height: 20px;
+  width: 15px;
+  height: 15px;
 }
 
 .c5 {

--- a/src/features/rewards/grantWrapper/style.ts
+++ b/src/features/rewards/grantWrapper/style.ts
@@ -58,15 +58,15 @@ export const StyledTitle = styled<StyleProps, 'div'>('div')`
 
 export const StyledClose = styled<{}, 'button'>('button')`
   top: 16px;
-  right: 16px;
+  right: 15px;
   position: absolute;
   padding: 0;
   border: none;
   background: none;
   cursor: pointer;
   color: #B8B9C4;
-  width: 20px;
-  height: 20px;
+  width: 15px;
+  height: 15px;
 `
 
 export const StyledText = styled<{}, 'div'>('div')`

--- a/src/features/rewards/walletWrapper/style.ts
+++ b/src/features/rewards/walletWrapper/style.ts
@@ -250,7 +250,7 @@ export const StyledBAT = styled<{}, 'div'>('div')`
 export const StyledNotificationIcon = styled<StyledProps, 'img'>('img')`
   height: 53px;
   width: 53px;
-  margin: 8px auto 0px;
+  margin: 9px 5px 0px 15px;
 `
 
 export const StyledNotificationCloseIcon = styled<StyledProps, 'div'>('div')`
@@ -297,7 +297,7 @@ export const StyledDateText = styled<StyledProps, 'span'>('span')`
 
 export const StyledButton = styled<StyledProps, 'div'>('div')`
   width: 88px;
-  margin: 12px auto 15px;
+  margin: 12px 122px 15px 125px;
 `
 
 export const StyledPipe = styled<StyledProps, 'span'>('span')`


### PR DESCRIPTION
## Changes
Adjusts close icon size, grant claim icon alignment on notification, small grant claim button adjustment

## Test plan
https://brave-ui-j53nddfrk.now.sh

Changes can be verified in the storybook

##### Link / storybook path to visual changes
- 
<!-- can be localhost storybook or `now` deployment -->

## Integration
- [ ] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [ ] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [ ] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
