### PR TITLE
Fixes captcha target clipping issue

### DIFF
--- a/src/features/rewards/grantCaptcha/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/grantCaptcha/__snapshots__/spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Grant captcha tests basic tests matches the snapshot 1`] = `
 .c0 {
   text-align: center;
-  margin: 28px 0 0 -32px;
+  margin: 15px 0 0 -32px;
   width: 333px;
 }
 
@@ -21,7 +21,6 @@ exports[`Grant captcha tests basic tests matches the snapshot 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  padding-bottom: 20px;
 }
 
 .c2 {

--- a/src/features/rewards/grantCaptcha/style.ts
+++ b/src/features/rewards/grantCaptcha/style.ts
@@ -6,7 +6,7 @@ import styled from 'styled-components'
 
 export const StyledWrapper = styled<{}, 'div'>('div')`
   text-align: center;
-  margin: 28px 0 0 -32px;
+  margin: 15px 0 0 -32px;
   width: 333px;
 `
 
@@ -18,7 +18,6 @@ export const StyledDropArea = styled<{}, 'img'>('img')`
 export const StyledDrag = styled<{}, 'div'>('div')`
   display: flex;
   justify-content: center;
-  padding-bottom: 20px;
 `
 
 export const StyledImageWrap = styled<{}, 'div'>('div')`

--- a/src/features/rewards/grantWrapper/style.ts
+++ b/src/features/rewards/grantWrapper/style.ts
@@ -86,8 +86,9 @@ export const StyledGrantIcon = styled<{}, 'img'>('img')`
 `
 
 export const StyledPanelText = styled<{}, 'div'>('div')`
-  margin-top: 7px;
   padding: 7px;
+  font-size: 12px;
+  margin: 7px auto 0px;
   background: rgba(241, 241, 245, 0.70);
   border-radius: 8px 8px 8px 8px;
 `


### PR DESCRIPTION
## Changes
A couple of stylistic changes to ensure that the captcha drop image is not clipped, as is the case when drop targets are closer to the bottom of the image.

Before on `brave-core` feature:
<img width="370" alt="screen shot 2018-12-18 at 11 15 42 pm" src="https://user-images.githubusercontent.com/8732757/50202754-56b23d00-031c-11e9-9692-18c7b32481b4.png">

After on `brave-core` feature:
<img width="380" alt="screen shot 2018-12-18 at 11 24 54 pm" src="https://user-images.githubusercontent.com/8732757/50202770-692c7680-031c-11e9-9cce-c231a2d60385.png">


## Test plan
View changes: https://brave-ui-12tmvvviv.now.sh

##### Link / storybook path to visual changes
- 
<!-- can be localhost storybook or `now` deployment -->

## Integration
- [ ] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [ ] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [ ] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
