### PR TITLE
Allows for custom publisher logo in donationOverlay

### DIFF
--- a/src/features/rewards/donationOverlay/index.tsx
+++ b/src/features/rewards/donationOverlay/index.tsx
@@ -23,7 +23,10 @@ import {
   StyledImageBorder,
   StyleSubHeaderText,
   StyledLetter,
-  StyledClose
+  StyledClose,
+  StyledLogoWrapper,
+  StyledLogoBorder,
+  StyledLogoImage
 } from './style'
 import { getLocale } from '../../../helpers'
 import { CloseCircleIcon, CloseStrokeIcon, PaperAirplaneIcon } from '../../../components/icons'
@@ -35,6 +38,7 @@ export interface Props {
   siteImg?: string
   domain?: string
   logoBgColor?: CSS.Color
+  logo?: string
   subText?: React.ReactNode
   onClose: () => void
 }
@@ -58,7 +62,7 @@ export default class DonationOverlay extends React.PureComponent<Props, {}> {
   }
 
   getOverlayContent = () => {
-    const { success, send, siteImg, subText, domain, logoBgColor } = this.props
+    const { success, send, siteImg, subText, logo, domain, logoBgColor } = this.props
     return (
       <StyledOverlayContent>
         {
@@ -80,10 +84,19 @@ export default class DonationOverlay extends React.PureComponent<Props, {}> {
               : null
             }
             {
-              !send && !siteImg && domain
+              !send && !siteImg && !logo && domain
               ? <StyledLetter logoBgColor={logoBgColor}>
                 {(domain && domain.substring(0,1)) || ''}
               </StyledLetter>
+              : null
+            }
+            {
+              !send && !siteImg && logo
+              ? <StyledLogoWrapper>
+                  <StyledLogoBorder bg={logoBgColor}>
+                    <StyledLogoImage bg={logo} />
+                  </StyledLogoBorder>
+                </StyledLogoWrapper>
               : null
             }
             </StyledIconWrapper>

--- a/src/features/rewards/donationOverlay/style.ts
+++ b/src/features/rewards/donationOverlay/style.ts
@@ -7,6 +7,7 @@ import styled from 'styled-components'
 import * as CSS from 'csstype'
 
 interface StyleProps {
+  bg?: string
   src?: string
   success?: boolean
   logoBgColor?: CSS.Color
@@ -146,15 +147,15 @@ export const StyleSubHeaderText = styled<{}, 'div'>('div')`
 export const StyledLetter = styled<StyleProps, 'div'>('div')`
   border: 6px solid #fff;
   border-radius: 50%;
-  width: 90px;
-  height: 90px;
+  width: 102px;
+  height: 102px;
   background: ${p => p.logoBgColor || '#DE4D26'};
   overflow: hidden;
-  margin-right: 25px;
+  margin: -12px 25px 0 0;
   color: #fff;
   text-align: center;
-  line-height: 78px;
-  font-size: 60px;
+  line-height: 90px;
+  font-size: 65px;
   text-transform: uppercase;
 `
 export const StyledClose = styled<{}, 'button'>('button')`
@@ -169,4 +170,26 @@ export const StyledClose = styled<{}, 'button'>('button')`
   height: 27px;
   color: #FFF;
   z-index: 2;
+`
+
+export const StyledLogoImage = styled<StyleProps, 'div'>('div')`
+  width: 90px;
+  height: 90px;
+  background: url(${p => p.bg}) no-repeat;
+  background-size: cover;
+`
+
+export const StyledLogoWrapper = styled<{}, 'div'>('div')`
+  padding-right: 25px;
+  flex-basis: 217px;
+`
+
+export const StyledLogoBorder = styled<StyleProps, 'div'>('div')`
+  border: 6px solid #fff;
+  border-radius: 50%;
+  width: 102px;
+  height: 102px;
+  margin-top: -12px;
+  background: ${p => p.bg || '#DE4D26'};
+  overflow: hidden;
 `

--- a/stories/features/rewards/other.tsx
+++ b/stories/features/rewards/other.tsx
@@ -36,6 +36,7 @@ import GrantClaim from '../../../src/features/rewards/grantClaim'
 const donate = require('../../assets/img/rewards_donate.svg')
 const bart = require('../../assets/img/bartBaker.jpeg')
 const tipScreen = require('../../assets/img/tip_site.jpg')
+const siteBgLogo = require('../../assets/img/ddgo_siteBanner.svg')
 
 const dummyClick = () => {
   console.log(dummyClick)
@@ -292,7 +293,8 @@ storiesOf('Feature Components/Rewards/Other/Desktop', module)
                 success={boolean('Success', false)}
                 send={boolean('Is send page?', true)}
                 subText={text('Sub header', 'This is text.')}
-                domain={'brave.com'}
+                domain={'duckduckgo.com'}
+                logo={boolean('Show logo', false) ? siteBgLogo : null}
             />
             : null
           }


### PR DESCRIPTION
Related: https://github.com/brave/brave-browser/issues/2668

## Changes
Adds support custom publisher logo in the donationOverlay component. Implementation and styling is similar to how it is in siteBanner.

## Test plan
Please view the donationOverlay concept in Rewards > Other in the provided storybook (https://brave-ui-4ty18cf5o.now.sh)

This is the knob configuration for getting the custom logo to show:

<img width="295" alt="screen shot 2018-12-20 at 11 47 52 am" src="https://user-images.githubusercontent.com/8732757/50304589-9a589400-044d-11e9-83a4-5c1b0e2bdb09.png">

Preview: 
<img width="650" alt="screen shot 2018-12-20 at 11 52 34 am" src="https://user-images.githubusercontent.com/8732757/50304664-ca079c00-044d-11e9-982c-cb2fed67f4a0.png">

##### Link / storybook path to visual changes
- 
<!-- can be localhost storybook or `now` deployment -->

## Integration
- [ ] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [ ] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [x] Will you create brave-core PR to update to this commit after it is merged?
  - [x] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.60.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
