### PR TITLE
make switch toggle grid with only 1 row

### DIFF
--- a/src/features/sync/grid/index.ts
+++ b/src/features/sync/grid/index.ts
@@ -19,7 +19,7 @@ export const EnabledContentButtonGrid = styled<{}, 'footer'>('footer')`
 export const SettingsToggleGrid = styled<{}, 'footer'>('footer')`
   display: grid;
   grid-template-columns: auto 1fr;
-  grid-template-rows: 1fr 1fr 1fr;
+  grid-template-rows: 1fr;
   grid-gap: 5px;
   align-items: center;
   margin: 15px 0 0;


### PR DESCRIPTION
address https://github.com/brave/brave-browser/issues/2676

## Changes

## Test plan

1. Go to Sync and `Enabled Content` screen
2. Check that `bookmarks` toggle only contains 1 row

##### Link / storybook path to visual changes
- n/a
<!-- can be localhost storybook or `now` deployment -->

## Integration
- [ ] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [ ] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [x] Will you create brave-core PR to update to this commit after it is merged?
  - [x] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
