### PR TITLE
Removes change settings in the panel

### DIFF
--- a/src/features/rewards/walletPanel/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/walletPanel/__snapshots__/spec.tsx.snap
@@ -50,12 +50,6 @@ exports[`WalletPanel tests basic tests matches the snapshot 1`] = `
   color: #7C7D8C;
 }
 
-.c22 {
-  text-align: center;
-  padding: 15px 0 0;
-  margin: 0 auto;
-}
-
 .c16 {
   margin-top: 6px;
 }
@@ -82,7 +76,7 @@ exports[`WalletPanel tests basic tests matches the snapshot 1`] = `
   flex: 1 0 0;
 }
 
-.c25 {
+.c22 {
   display: none;
 }
 
@@ -213,35 +207,6 @@ exports[`WalletPanel tests basic tests matches the snapshot 1`] = `
   color: #4B4C5C;
 }
 
-.c23 {
-  width: 100%;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  color: white;
-  font-size: 14px;
-  border-radius: 28px;
-  background: inherit;
-  cursor: pointer;
-  height: 40px;
-  color: #4C54D2;
-  border-radius: 20px;
-  font-size: 12px;
-  border: 1px solid #A1A8F2;
-}
-
-.c24 {
-  font-family: Poppins,sans-serif;
-  font-weight: 600;
-  text-transform: uppercase;
-  -webkit-letter-spacing: 0.39px;
-  -moz-letter-spacing: 0.39px;
-  -ms-letter-spacing: 0.39px;
-  letter-spacing: 0.39px;
-  margin: 0 auto;
-}
-
 <div
   className="c0"
 >
@@ -367,23 +332,9 @@ exports[`WalletPanel tests basic tests matches the snapshot 1`] = `
         </div>
       </div>
     </section>
-    <div
-      className="c22"
-    >
-      <button
-        className="c23"
-        type="tip"
-      >
-        <span
-          className="c24"
-        >
-          MISSING: donateNow
-        </span>
-      </button>
-    </div>
   </div>
   <div
-    className="c25"
+    className="c22"
   />
 </div>
 `;

--- a/src/features/rewards/walletPanel/index.tsx
+++ b/src/features/rewards/walletPanel/index.tsx
@@ -23,8 +23,7 @@ import {
   StyledColumn,
   StyleToggleTips,
   StyledNoticeWrapper,
-  StyledNoticeLink,
-  StyledChangeButton
+  StyledNoticeLink
 } from './style'
 
 // Components
@@ -59,9 +58,7 @@ export interface Props {
   onAmountChange: () => void
   onIncludeInAuto: () => void
   showUnVerified?: boolean
-  showChangeSetting?: boolean
   moreLink?: string
-  onChangeSetting?: () => void
 }
 
 export default class WalletPanel extends React.PureComponent<Props, {}> {
@@ -167,9 +164,7 @@ export default class WalletPanel extends React.PureComponent<Props, {}> {
       toggleTips,
       showUnVerified,
       isVerified,
-      moreLink,
-      showChangeSetting,
-      onChangeSetting
+      moreLink
     } = this.props
 
     return (
@@ -181,11 +176,6 @@ export default class WalletPanel extends React.PureComponent<Props, {}> {
             ? <StyledNoticeWrapper>
               {getLocale('unVerifiedText')}
               <StyledNoticeLink href={moreLink} target={'_blank'}> {getLocale('unVerifiedTextMore')}</StyledNoticeLink>
-              {
-                showChangeSetting
-                ? <StyledChangeButton onClick={onChangeSetting}>{getLocale('changeSettingsButton')}</StyledChangeButton>
-                : null
-              }
             </StyledNoticeWrapper>
             : null
           }
@@ -206,13 +196,17 @@ export default class WalletPanel extends React.PureComponent<Props, {}> {
           <StyledControlsWrapper>
             {this.donationControls()}
           </StyledControlsWrapper>
-          <StyledDonateWrapper>
-            <RewardsButton
-              type={'tip'}
-              onClick={donationAction}
-              text={getLocale('donateNow')}
-            />
-          </StyledDonateWrapper>
+          {
+            tipsEnabled
+            ? <StyledDonateWrapper>
+              <RewardsButton
+                type={'tip'}
+                onClick={donationAction}
+                text={getLocale('donateNow')}
+              />
+            </StyledDonateWrapper>
+            : null
+          }
         </StyledContainer>
         <StyleToggleTips toggleTips={toggleTips}>
           <ToggleTips

--- a/src/features/rewards/walletPanel/style.ts
+++ b/src/features/rewards/walletPanel/style.ts
@@ -100,13 +100,3 @@ export const StyledNoticeLink = styled<StyleProps, 'a'>('a')`
   display: inline-block;
   margin-left: 4px;
 `
-
-export const StyledChangeButton = styled<StyleProps, 'button'>('button')`
-  font-family: ${p => p.theme.fontFamily.body};
-  font-weight: bold;
-  background: none;
-  border: none;
-  padding: 0;
-  margin-top: 2px;
-  cursor: pointer;
-`

--- a/src/features/rewards/walletSummary/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/walletSummary/__snapshots__/spec.tsx.snap
@@ -185,9 +185,9 @@ exports[`WalletSummary tests basic tests matches the snapshot 1`] = `
     <div
       className="c3"
     >
-      MISSING: monthDec
+      MISSING: monthJan
        
-      2018
+      2019
     </div>
     <div>
       <div


### PR DESCRIPTION
Part of https://github.com/brave/brave-core/pull/1206


## Changes
- Adds option to hide tip button in the panel
- Removes change settings in the panel
## Test plan


##### Link / storybook path to visual changes
- 
<!-- can be localhost storybook or `now` deployment -->

## Integration
- [ ] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [ ] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [ ] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
