### PR TITLE
Adds reserved amount to wallet summary

### DIFF
--- a/src/features/rewards/walletPanel/index.tsx
+++ b/src/features/rewards/walletPanel/index.tsx
@@ -23,8 +23,7 @@ import {
   StyledColumn,
   StyleToggleTips,
   StyledNoticeWrapper,
-  StyledNoticeLink,
-  StyledChangeButton
+  StyledNoticeLink
 } from './style'
 
 // Components
@@ -59,9 +58,7 @@ export interface Props {
   onAmountChange: () => void
   onIncludeInAuto: () => void
   showUnVerified?: boolean
-  showChangeSetting?: boolean
   moreLink?: string
-  onChangeSetting?: () => void
 }
 
 export default class WalletPanel extends React.PureComponent<Props, {}> {
@@ -167,9 +164,7 @@ export default class WalletPanel extends React.PureComponent<Props, {}> {
       toggleTips,
       showUnVerified,
       isVerified,
-      moreLink,
-      showChangeSetting,
-      onChangeSetting
+      moreLink
     } = this.props
 
     return (
@@ -181,11 +176,6 @@ export default class WalletPanel extends React.PureComponent<Props, {}> {
             ? <StyledNoticeWrapper>
               {getLocale('unVerifiedText')}
               <StyledNoticeLink href={moreLink} target={'_blank'}> {getLocale('unVerifiedTextMore')}</StyledNoticeLink>
-              {
-                showChangeSetting
-                ? <StyledChangeButton onClick={onChangeSetting}>{getLocale('changeSettingsButton')}</StyledChangeButton>
-                : null
-              }
             </StyledNoticeWrapper>
             : null
           }

--- a/src/features/rewards/walletPanel/index.tsx
+++ b/src/features/rewards/walletPanel/index.tsx
@@ -174,8 +174,7 @@ export default class WalletPanel extends React.PureComponent<Props, {}> {
           {
             !isVerified && showUnVerified
             ? <StyledNoticeWrapper>
-              {getLocale('unVerifiedText')}
-              <StyledNoticeLink href={moreLink} target={'_blank'}> {getLocale('unVerifiedTextMore')}</StyledNoticeLink>
+              {getLocale('unVerifiedText')} <StyledNoticeLink href={moreLink} target={'_blank'}> {getLocale('unVerifiedTextMore')}</StyledNoticeLink>
             </StyledNoticeWrapper>
             : null
           }

--- a/src/features/rewards/walletPanel/style.ts
+++ b/src/features/rewards/walletPanel/style.ts
@@ -3,6 +3,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import styled from 'styled-components'
+import palette from '../../../theme/palette'
 
 interface StyleProps {
   size?: string
@@ -94,9 +95,8 @@ export const StyledNoticeWrapper = styled<StyleProps, 'div'>('div')`
 `
 
 export const StyledNoticeLink = styled<StyleProps, 'a'>('a')`
-  color: #0089FF;
+  color: ${palette.blue400};
   font-weight: bold;
   text-decoration: none;
   display: inline-block;
-  margin-left: 4px;
 `

--- a/src/features/rewards/walletPanel/style.ts
+++ b/src/features/rewards/walletPanel/style.ts
@@ -100,13 +100,3 @@ export const StyledNoticeLink = styled<StyleProps, 'a'>('a')`
   display: inline-block;
   margin-left: 4px;
 `
-
-export const StyledChangeButton = styled<StyleProps, 'button'>('button')`
-  font-family: ${p => p.theme.fontFamily.body};
-  font-weight: bold;
-  background: none;
-  border: none;
-  padding: 0;
-  margin-top: 2px;
-  cursor: pointer;
-`

--- a/src/features/rewards/walletSummary/index.tsx
+++ b/src/features/rewards/walletSummary/index.tsx
@@ -11,7 +11,9 @@ import {
   StyledActivity,
   StyledActivityIcon,
   StyledNoActivity,
-  StyledNoActivityWrapper
+  StyledNoActivityWrapper,
+  StyledReservedWrapper,
+  StyledReservedLink
 } from './style'
 import ListToken from '../listToken'
 import { Type } from '../tokens'
@@ -36,6 +38,8 @@ export interface Props {
   }
   id?: string
   compact?: boolean
+  reservedAmount?: number
+  reservedMoreLink?: string
 }
 
 export default class WalletSummary extends React.PureComponent<Props, {}> {
@@ -117,7 +121,9 @@ export default class WalletSummary extends React.PureComponent<Props, {}> {
     const {
       id,
       onActivity,
-      compact
+      compact,
+      reservedAmount,
+      reservedMoreLink
     } = this.props
     const date = new Date()
     const month = getLocale(`month${date.toLocaleString('en-us', { month: 'short' })}`)
@@ -133,6 +139,16 @@ export default class WalletSummary extends React.PureComponent<Props, {}> {
           <StyledTitle>{month} {year}</StyledTitle>
           <div>
             {this.generateList()}
+            {
+              reservedAmount && reservedAmount > 0
+              ? <StyledReservedWrapper>
+                {getLocale('reservedAmountText', { reservedAmount })}
+                <StyledReservedLink href={reservedMoreLink} target={'_blank'}>
+                  {getLocale('reservedMoreLink')}
+                </StyledReservedLink>
+              </StyledReservedWrapper>
+              : null
+            }
           </div>
           {
             onActivity

--- a/src/features/rewards/walletSummary/index.tsx
+++ b/src/features/rewards/walletSummary/index.tsx
@@ -142,8 +142,7 @@ export default class WalletSummary extends React.PureComponent<Props, {}> {
             {
               reservedAmount && reservedAmount > 0
               ? <StyledReservedWrapper>
-                {getLocale('reservedAmountText', { reservedAmount })}
-                <StyledReservedLink href={reservedMoreLink} target={'_blank'}>
+                {getLocale('reservedAmountText', { reservedAmount })} <StyledReservedLink href={reservedMoreLink} target={'_blank'}>
                   {getLocale('reservedMoreLink')}
                 </StyledReservedLink>
               </StyledReservedWrapper>

--- a/src/features/rewards/walletSummary/style.ts
+++ b/src/features/rewards/walletSummary/style.ts
@@ -73,3 +73,24 @@ export const StyledNoActivity = styled<{}, 'span'>('span')`
   color: #B8B9C4;
   font-size: 18px;
 `
+
+export const StyledReservedWrapper = styled<{}, 'div'>('div')`
+  background: rgba(0, 0, 0, 0.04);
+  color: #676283;
+  font-size: 12px;
+  font-family: ${p => p.theme.fontFamily.body};
+  font-weight: normal;
+  letter-spacing: 0;
+  line-height: 16px;
+  padding: 10px 12px;
+  border-radius: 4px;
+  margin: 20px 0 10px;
+`
+
+export const StyledReservedLink = styled<StyleProps, 'a'>('a')`
+  color: #0089FF;
+  font-weight: bold;
+  text-decoration: none;
+  display: inline-block;
+  margin-left: 4px;
+`

--- a/src/features/rewards/walletSummary/style.ts
+++ b/src/features/rewards/walletSummary/style.ts
@@ -3,6 +3,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import styled from 'styled-components'
+import palette from '../../../theme/palette'
 
 interface StyleProps {
   compact?: boolean
@@ -88,9 +89,8 @@ export const StyledReservedWrapper = styled<{}, 'div'>('div')`
 `
 
 export const StyledReservedLink = styled<StyleProps, 'a'>('a')`
-  color: #0089FF;
+  color: ${palette.blue400};
   font-weight: bold;
   text-decoration: none;
   display: inline-block;
-  margin-left: 4px;
 `

--- a/src/features/rewards/walletWrapper/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/walletWrapper/__snapshots__/spec.tsx.snap
@@ -57,7 +57,7 @@ exports[`WalletWrapper tests basic tests matches the snapshot 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
-  height: 361px;
+  height: 381px;
 }
 
 .c6 {

--- a/src/features/rewards/walletWrapper/style.ts
+++ b/src/features/rewards/walletWrapper/style.ts
@@ -78,7 +78,7 @@ export const StyledContent = styled<StyledProps, 'div'>('div')`
   position: relative;
   background: #f9fbfc;
   flex: 1;
-  height: 361px;
+  height: 381px;
 `
 
 export const StyledAction = styled<{}, 'button'>('button')`

--- a/stories/assets/locale.ts
+++ b/stories/assets/locale.ts
@@ -36,7 +36,6 @@ const locale: Record<string, string> = {
   captchaMissedTarget: 'Hmm… Not Quite. Try Again.',
   claim: 'Claim',
   closeBalance: 'Closing Balance',
-  changeSettingsButton: 'Change Auto-Contribute settings',
   contribute: 'Contribute',
   contributeAllocation: 'Auto-Contribute Allocation',
   contributeTooltip: 'Auto-Contribute Settings',

--- a/stories/assets/locale.ts
+++ b/stories/assets/locale.ts
@@ -123,6 +123,8 @@ const locale: Record<string, string> = {
   recurringDonation: 'Recurring Donation',
   recurringDonations: 'Monthly Tips',
   remove: 'remove',
+  reservedAmountText: 'You’ve designated {{reservedAmount}} BAT for creators who haven’t yet signed up to receive contributions. We’ll keep trying to contribute until they verify, or until 90 days have passed.',
+  reservedMoreLink: 'Learn more.',
   restore: 'Restore',
   restoreAll: 'Restore All',
   reviewSitesMsg: 'Your pinned sites have been moved to',

--- a/stories/features/rewards/wallet.tsx
+++ b/stories/features/rewards/wallet.tsx
@@ -137,7 +137,6 @@ storiesOf('Feature Components/Rewards/Wallet/Desktop', module)
           onAmountChange={doNothing}
           onIncludeInAuto={doNothing}
           showUnVerified={boolean('Show unverified content', true)}
-          showChangeSetting={boolean('Show change setting', true)}
         />
       </div>
     )

--- a/stories/features/rewards/wallet.tsx
+++ b/stories/features/rewards/wallet.tsx
@@ -4,7 +4,7 @@
 
 import * as React from 'react'
 import { storiesOf } from '@storybook/react'
-import { withKnobs, object, select, text, boolean } from '@storybook/addon-knobs'
+import { withKnobs, object, select, text, boolean, number } from '@storybook/addon-knobs'
 // @ts-ignore
 import centered from '@storybook/addon-centered/dist'
 
@@ -93,6 +93,8 @@ storiesOf('Feature Components/Rewards/Wallet/Desktop', module)
             tips: object('Tips', { tokens: '19.0', converted: '5.25' })
           }}
           onActivity={doNothing}
+          reservedAmount={number('Reserved amount', 52)}
+          reservedMoreLink={'https://brave.com'}
         />
       </div>
     )


### PR DESCRIPTION
## Changes
- adds info about reserved funds in wallet summary
- removes change setting button from the panel

## Test plan


##### Link / storybook path to visual changes
- https://brave-ui-drej78cr4.now.sh
<!-- can be localhost storybook or `now` deployment -->

## Integration
- [ ] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [ ] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [ ] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
