### PR TITLE
Adds backup link action to backup notification

### DIFF
--- a/src/features/rewards/walletWrapper/index.tsx
+++ b/src/features/rewards/walletWrapper/index.tsx
@@ -34,7 +34,8 @@ import {
   StyledNotificationContent,
   StyledButton,
   StyledNotificationMessage,
-  StyledPipe
+  StyledPipe,
+  StyledBackupLink
 } from './style'
 import { getLocale } from '../../../helpers'
 import { GrantCaptcha, GrantComplete, GrantError, GrantWrapper } from '../'
@@ -109,6 +110,7 @@ export interface Props {
   gradientTop?: string
   isMobile?: boolean
   notification?: Notification
+  onBackupLink?: () => void
   onFetchCaptcha?: () => void
   onGrantHide?: () => void
   onFinish?: () => void
@@ -144,6 +146,12 @@ export default class WalletWrapper extends React.PureComponent<Props, State> {
   onFetchCaptcha = () => {
     if (this.props.onFetchCaptcha) {
       this.props.onFetchCaptcha()
+    }
+  }
+
+  onBackupLink = () => {
+    if (this.props.onBackupLink) {
+      this.props.onBackupLink()
     }
   }
 
@@ -330,7 +338,11 @@ export default class WalletWrapper extends React.PureComponent<Props, State> {
         typeText = getLocale('braveAdsTitle')
         break
       case 'backupWallet':
-        typeText = getLocale('backupWalletTitle')
+        typeText = (
+          <StyledBackupLink onClick={this.onBackupLink}>
+            {getLocale('backupWalletTitle')}
+          </StyledBackupLink>
+        )
         break
       case 'contribute':
         typeText = getLocale('braveContributeTitle')

--- a/src/features/rewards/walletWrapper/style.ts
+++ b/src/features/rewards/walletWrapper/style.ts
@@ -303,3 +303,8 @@ export const StyledButton = styled<StyledProps, 'div'>('div')`
 export const StyledPipe = styled<StyledProps, 'span'>('span')`
   font-weight: 300;
 `
+
+export const StyledBackupLink = styled<StyledProps, 'a'>('a')`
+  cursor: pointer;
+  text-decoration: none;
+`

--- a/stories/assets/locale.ts
+++ b/stories/assets/locale.ts
@@ -16,6 +16,7 @@ const locale: Record<string, string> = {
   allowTip: 'Allow tips on',
   amount: 'Amount',
   backup: 'Backup',
+  backupWalletTitle: 'Backup Wallet',
   braveAdsDesc: 'No action required. Just collect tokens. Your data is safe with our Shields.',
   braveAdsTitle: 'Brave Ads',
   braveContributeDesc: 'Set budget and browse normally. Your favorite sites get paid automatically.',


### PR DESCRIPTION
Related: https://github.com/brave/brave-browser/issues/2739

<img width="334" alt="screen shot 2019-01-22 at 12 27 07 am" src="https://user-images.githubusercontent.com/8732757/51518851-7a194d80-1ddc-11e9-90e2-91e4bb3d592f.png">


## Changes
Making the `Backup Wallet` text in the backup notification actionable, fixed locale

## Test plan


##### Link / storybook path to visual changes
**No changes visible in the storybook**
- 
<!-- can be localhost storybook or `now` deployment -->

## Integration
- [ ] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [ ] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [ ] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
