### PR TITLE
Opt In Button 

### DIFF
--- a/src/components/buttonsIndicators/button/index.tsx
+++ b/src/components/buttonsIndicators/button/index.tsx
@@ -26,7 +26,7 @@ export interface Props {
 }
 
 export type Level = 'primary' | 'secondary' | 'tertiary'
-export type Type = 'default' | 'accent' | 'warn' | 'subtle'
+export type Type = 'default' | 'accent' | 'warn' | 'subtle' | 'white'
 export type Brand = 'brave' | 'rewards'
 export type Size = 'call-to-action' | 'large' | 'medium' | 'small'
 

--- a/src/components/buttonsIndicators/button/style.ts
+++ b/src/components/buttonsIndicators/button/style.ts
@@ -54,6 +54,11 @@ const getThemeColors = (p: ThemedStyledProps<Props>) => {
         hoverColor = p.theme.color.subtleInteracting
         activeColor = p.theme.color.subtleActive
         break
+      case 'white':
+        mainColor = '#FFFFFF'
+        hoverColor = '#FEFEFE'
+        activeColor = '#FFFFFF'
+        break
     }
   }
   return css`

--- a/src/features/rewards/panelWelcome/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/panelWelcome/__snapshots__/spec.tsx.snap
@@ -109,9 +109,9 @@ exports[`PanelWelcome tests basic tests matches the snapshot 1`] = `
 }
 
 .c12 {
-  --button-main-color: #A0A1B2;
-  --button-main-color-hover: #7C7D8C;
-  --button-main-color-active: #585968;
+  --button-main-color: #FFFFFF;
+  --button-main-color-hover: #FEFEFE;
+  --button-main-color-active: #FFFFFF;
   --button-state-color: var(--button-main-color);
   --icon-size: 18px;
   --icon-spacing: 6px;
@@ -245,12 +245,12 @@ exports[`PanelWelcome tests basic tests matches the snapshot 1`] = `
       <button
         className="c11 c12"
         size="call-to-action"
-        type="subtle"
+        type="white"
       >
         <div
           className="c13"
           size="call-to-action"
-          type="subtle"
+          type="white"
         >
           MISSING: welcomeButtonTextOne
         </div>

--- a/src/features/rewards/panelWelcome/index.tsx
+++ b/src/features/rewards/panelWelcome/index.tsx
@@ -86,7 +86,7 @@ export default class PanelWelcome extends React.PureComponent<Props, {}> {
               ? <Button
                 level='secondary'
                 size='call-to-action'
-                type='subtle'
+                type='white'
                 text={'Creating wallet'}
                 disabled={true}
                 data-test-id='optInAction'
@@ -103,7 +103,7 @@ export default class PanelWelcome extends React.PureComponent<Props, {}> {
                     <Button
                       level='secondary'
                       size='call-to-action'
-                      type='subtle'
+                      type='white'
                       text={getLocale('walletFailedButton')}
                       onClick={optInErrorAction}
                       data-test-id='optInErrorAction'
@@ -111,7 +111,7 @@ export default class PanelWelcome extends React.PureComponent<Props, {}> {
                   </>
                 : <Button
                   size='call-to-action'
-                  type='subtle'
+                  type='white'
                   level='secondary'
                   onClick={optInAction}
                   text={getLocale(this.locale.button)}


### PR DESCRIPTION
Addresses: https://github.com/brave/brave-browser/issues/3218

Since there are upcoming button component styling consolidation initiatives, I think adding this prop to the base button component to allow for white buttons instead of always defaulting to `subtle` is helpful in the interim. Regardless, white buttons will be a needed styling so this style is forthcoming anyway.

## Before
<img width="297" alt="screen shot 2019-02-04 at 4 39 58 pm" src="https://user-images.githubusercontent.com/29072694/52249304-3546e980-28a7-11e9-879e-e1af963937a1.png">

## After
![image](https://user-images.githubusercontent.com/29072694/52249296-2eb87200-28a7-11e9-8904-ccd1a3e41eaf.png)
