### PR TITLE
Various Android fixes

### DIFF
--- a/src/components/popupModals/modal/index.tsx
+++ b/src/components/popupModals/modal/index.tsx
@@ -14,6 +14,7 @@ export interface Props {
   size?: 'small' | 'normal'
   testId?: string
   displayCloseButton?: boolean
+  isMobile?: boolean
 }
 
 export default class Modal extends React.PureComponent<Props, {}> {
@@ -34,7 +35,15 @@ export default class Modal extends React.PureComponent<Props, {}> {
   }
 
   render () {
-    const { id, onClose, displayCloseButton, children, size, testId } = this.props
+    const {
+      id,
+      onClose,
+      displayCloseButton,
+      children,
+      size,
+      testId,
+      isMobile
+    } = this.props
 
     return (
       <StyledWrapper id={id} onClick={this.outsideClose} data-test-id={testId}>
@@ -44,7 +53,7 @@ export default class Modal extends React.PureComponent<Props, {}> {
               ? <StyledClose onClick={onClose}><CloseCircleOIcon /></StyledClose>
               : null
           }
-          <StyledContent>
+          <StyledContent isMobile={isMobile}>
             {children}
           </StyledContent>
         </StyledDialog>

--- a/src/components/popupModals/modal/style.ts
+++ b/src/components/popupModals/modal/style.ts
@@ -5,6 +5,10 @@
 import styled from 'styled-components'
 import { Props } from './index'
 
+interface StyleProps {
+  isMobile?: boolean
+}
+
 export const StyledWrapper = styled<{}, 'div'>('div')`
   position: fixed;
   top: 0;
@@ -36,8 +40,8 @@ export const StyledClose = styled<{}, 'div'>('div')`
   color: #9E9FAB;
 `
 
-export const StyledContent = styled<{}, 'div'>('div')`
+export const StyledContent = styled<StyleProps, 'div'>('div')`
   padding: 48px 48px;
   overflow-y: auto;
-  max-height: calc(100vh - 100px);
+  max-height: calc(100vh - ${p => p.isMobile ? 170 : 100}px);
 `

--- a/src/features/rewards/list/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/list/__snapshots__/spec.tsx.snap
@@ -57,6 +57,14 @@ exports[`List tests basic tests matches the snapshot 1`] = `
   text-align: right;
 }
 
+@media (max-width:390px) {
+  .c2 {
+    -webkit-flex-basis: 80%;
+    -ms-flex-preferred-size: 80%;
+    flex-basis: 80%;
+  }
+}
+
 <div
   className="c0"
   id="list"

--- a/src/features/rewards/list/style.ts
+++ b/src/features/rewards/list/style.ts
@@ -31,4 +31,8 @@ export const StyledContentWrapper = styled<{}, 'div'>('div')`
   flex-shrink: 1;
   flex-basis: 50%;
   text-align: right;
+
+  @media (max-width: 390px) {
+    flex-basis: 80%;
+  }
 `

--- a/src/features/rewards/modalAddFunds/index.tsx
+++ b/src/features/rewards/modalAddFunds/index.tsx
@@ -114,10 +114,10 @@ export default class ModalAddFunds extends React.PureComponent<Props, State> {
   }
 
   render () {
-    const { id, onClose, addresses } = this.props
+    const { id, onClose, addresses, isMobile } = this.props
 
     return (
-      <Modal id={id} onClose={onClose}>
+      <Modal id={id} onClose={onClose} isMobile={isMobile}>
         <StyledWrapper>
           <StyledTitle>{getLocale('addFundsTitle')}</StyledTitle>
           <StyledText>


### PR DESCRIPTION
Related issues:
https://github.com/brave/browser-android-tabs/issues/1017
https://github.com/brave/browser-android-tabs/issues/984

## Changes
Reduces the maximum height for modals on android to accommodate for menu bars, increasing right hand column size for small viewports in rewards settings views
## Test plan
https://brave-ui-eqkrfzj48.now.sh

##### Link / storybook path to visual changes
Simulates viewport and menu from the pixel 3 xl in the issue (fix pictured)
<img width="401" alt="screen shot 2019-02-06 at 1 44 17 am" src="https://user-images.githubusercontent.com/8732757/52333637-fa35da80-29ba-11e9-959a-da770880ca68.png">

- 
<!-- can be localhost storybook or `now` deployment -->

## Integration
- [ ] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [ ] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [ ] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
