### PR TITLE
Fixes mobile settings header

### DIFF
--- a/src/features/rewards/mobile/boxMobile/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/mobile/boxMobile/__snapshots__/spec.tsx.snap
@@ -73,10 +73,10 @@ exports[`Box tests basic tests matches the snapshot 1`] = `
   -ms-letter-spacing: normal;
   letter-spacing: normal;
   display: inline-block;
-  vertical-align: default;
-  margin-left: 0px;
+  vertical-align: middle;
+  margin-left: 10px;
   color: #4b4c5c;
-  margin-top: 0px;
+  margin-top: -5px;
 }
 
 .c8 {

--- a/src/features/rewards/mobile/boxMobile/style.ts
+++ b/src/features/rewards/mobile/boxMobile/style.ts
@@ -74,13 +74,13 @@ export const StyledTitle = styled<StyleProps, 'div'>('div')`
   line-height: 1.27;
   letter-spacing: normal;
   display: inline-block;
-  vertical-align: ${p => p.contentShown ? 'top' : 'default'};
-  margin-left: ${p => p.contentShown ? 10 : 0}px;
+  vertical-align: ${p => p.contentShown ? 'top' : 'middle'};
+  margin-left: ${p => p.contentShown ? 10 : 10}px;
   color: ${p => {
     if (p.enabled === false) return '#838391'
     return p.type && colors[p.type] || '#4b4c5c'
   }};
-  margin-top: ${p => p.contentShown ? 3 : 0}px;
+  margin-top: ${p => p.contentShown ? 3 : -5}px;
 `
 
 export const StyledBreak = styled<{}, 'div'>('div')`
@@ -164,7 +164,7 @@ export const StyledDetailInfo = styled<{}, 'div'>('div')`
 `
 
 export const StyledDetailContent = styled<{}, 'div'>('div')`
-  margin-top: 75px;
+  margin-top: 80px;
 `
 
 export const StyledChildContent = styled<{}, 'div'>('div')`
@@ -240,6 +240,6 @@ export const StyledSettingsIcon = styled<{}, 'button'>('button')`
 `
 
 export const StyledToggleWrapper = styled<StyleProps, 'div'>('div')`
-  margin-right: ${p => p.contentShown ? '-5' : '-15'}px;
-  margin-top: ${p => p.contentShown ? 5 : 2}px;
+  margin-right: -5px;
+  margin-top: ${p => p.contentShown ? 5 : 6}px;
 `


### PR DESCRIPTION
Related:
https://github.com/brave/browser-android-tabs/issues/1094
https://github.com/brave/browser-android-tabs/issues/1090

## Changes
I'm not sure exactly when or why this broke, but this needed readjusting. It should look good at all mobile viewports now.

## Test plan

##### Link / storybook path to visual changes
https://brave-ui-jjtd75e7l.now.sh

Before: 
<img width="391" alt="screen shot 2019-02-08 at 4 28 54 am" src="https://user-images.githubusercontent.com/8732757/52476043-a6fa8e00-2b5a-11e9-87d0-b23827ab1aff.png">

After:
<img width="390" alt="screen shot 2019-02-08 at 4 29 01 am" src="https://user-images.githubusercontent.com/8732757/52476058-aeba3280-2b5a-11e9-8844-b829487cef55.png">


## Integration
- [ ] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [ ] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [ ] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
