### PR TITLE
Showing settings child in settings pane

### DIFF
--- a/src/features/rewards/mobile/boxMobile/index.tsx
+++ b/src/features/rewards/mobile/boxMobile/index.tsx
@@ -219,9 +219,9 @@ export default class BoxMobile extends React.PureComponent<Props, State> {
   }
 
   getSettingsContent = (show?: boolean) => {
-    const { title, children } = this.props
+    const { title, settingsChild } = this.props
 
-    if (!show) {
+    if (!show || !settingsChild) {
       return null
     }
 
@@ -235,7 +235,7 @@ export default class BoxMobile extends React.PureComponent<Props, State> {
             <CloseStrokeIcon />
           </StyledSettingsClose>
           <StyledSettingsContent>
-            {children}
+            {settingsChild}
           </StyledSettingsContent>
         </StyledSettingsHeader>
       </StyledFullSizeWrapper>


### PR DESCRIPTION
Related: https://github.com/brave/browser-android-tabs/issues/1093

## Changes
The view was incorrectly showing `children` instead of what is passed through `settingsChild`

## Test plan
Before:
<img width="391" alt="screen shot 2019-02-08 at 5 45 56 am" src="https://user-images.githubusercontent.com/8732757/52479270-4f155480-2b65-11e9-8ef1-fee719ffd641.png">

After:
<img width="391" alt="screen shot 2019-02-08 at 5 46 05 am" src="https://user-images.githubusercontent.com/8732757/52479280-53417200-2b65-11e9-9e0e-e9f88d97bf8e.png">


##### Link / storybook path to visual changes
https://brave-ui-bjbyvybmh.now.sh

## Integration
- [ ] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [ ] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [ ] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
