### PR TITLE
Adds action to backup wallet notification

### DIFF
--- a/src/features/rewards/walletWrapper/index.tsx
+++ b/src/features/rewards/walletWrapper/index.tsx
@@ -32,6 +32,7 @@ import {
   StyledMessageText,
   StyledDateText,
   StyledNotificationContent,
+  StyledButtonWrapper,
   StyledButton,
   StyledNotificationMessage,
   StyledPipe
@@ -260,7 +261,7 @@ export default class WalletWrapper extends React.PureComponent<Props, State> {
     }
 
     return (
-      <Button
+      <StyledButton
         size={'small'}
         type={'accent'}
         level={'primary'}
@@ -285,9 +286,9 @@ export default class WalletWrapper extends React.PureComponent<Props, State> {
         <StyledNotificationContent>
           {this.getNotificationIcon(notification)}
           {this.getNotificationMessage(notification)}
-          <StyledButton type={notification.type}>
+          <StyledButtonWrapper type={notification.type}>
             {this.getNotificationButton(notification.type, onClose)}
-          </StyledButton>
+          </StyledButtonWrapper>
         </StyledNotificationContent>
       </>
     )

--- a/src/features/rewards/walletWrapper/index.tsx
+++ b/src/features/rewards/walletWrapper/index.tsx
@@ -246,8 +246,8 @@ export default class WalletWrapper extends React.PureComponent<Props, State> {
   }
 
   getNotificationButton = (type: NotificationType, onClose: any) => {
-    let buttonText = 'OK'
-    let buttonAction = onClose
+    let buttonText
+    let buttonAction
 
     switch (type) {
       case 'grant':
@@ -257,6 +257,10 @@ export default class WalletWrapper extends React.PureComponent<Props, State> {
       case 'backupWallet':
         buttonText = getLocale('backupNow')
         buttonAction = this.onNotificationClick
+        break
+      default:
+        buttonText = getLocale('ok').toUpperCase()
+        buttonAction = onClose
         break
     }
 
@@ -286,7 +290,7 @@ export default class WalletWrapper extends React.PureComponent<Props, State> {
         <StyledNotificationContent>
           {this.getNotificationIcon(notification)}
           {this.getNotificationMessage(notification)}
-          <StyledButtonWrapper type={notification.type}>
+          <StyledButtonWrapper>
             {this.getNotificationButton(notification.type, onClose)}
           </StyledButtonWrapper>
         </StyledNotificationContent>

--- a/src/features/rewards/walletWrapper/index.tsx
+++ b/src/features/rewards/walletWrapper/index.tsx
@@ -109,7 +109,7 @@ export interface Props {
   gradientTop?: string
   isMobile?: boolean
   notification?: Notification
-  onFetchCaptcha?: () => void
+  onNotificationClick?: () => void
   onGrantHide?: () => void
   onFinish?: () => void
   onSolution?: (x: number, y: number) => void
@@ -141,9 +141,9 @@ export default class WalletWrapper extends React.PureComponent<Props, State> {
     })
   }
 
-  onFetchCaptcha = () => {
-    if (this.props.onFetchCaptcha) {
-      this.props.onFetchCaptcha()
+  onNotificationClick = () => {
+    if (this.props.onNotificationClick) {
+      this.props.onNotificationClick()
     }
   }
 
@@ -244,6 +244,32 @@ export default class WalletWrapper extends React.PureComponent<Props, State> {
     )
   }
 
+  getNotificationButton = (type: NotificationType, onClose: any) => {
+    let buttonText = 'OK'
+    let buttonAction = onClose
+
+    switch (type) {
+      case 'grant':
+        buttonText = getLocale('claim')
+        buttonAction = this.onNotificationClick
+        break
+      case 'backupWallet':
+        buttonText = getLocale('backupNow')
+        buttonAction = this.onNotificationClick
+        break
+    }
+
+    return (
+      <Button
+        size={'small'}
+        type={'accent'}
+        level={'primary'}
+        onClick={buttonAction}
+        text={buttonText}
+      />
+    )
+  }
+
   generateNotification = (notification: Notification | undefined) => {
     if (!notification) {
       return null
@@ -259,24 +285,8 @@ export default class WalletWrapper extends React.PureComponent<Props, State> {
         <StyledNotificationContent>
           {this.getNotificationIcon(notification)}
           {this.getNotificationMessage(notification)}
-          <StyledButton>
-            {
-              notification.type === 'grant'
-                ? <Button
-                  size={'small'}
-                  type={'accent'}
-                  level={'primary'}
-                  onClick={this.onFetchCaptcha}
-                  text={getLocale('claim')}
-                />
-                : <Button
-                  size={'small'}
-                  type={'accent'}
-                  level={'primary'}
-                  onClick={onClose}
-                  text={'OK'}
-                />
-            }
+          <StyledButton type={notification.type}>
+            {this.getNotificationButton(notification.type, onClose)}
           </StyledButton>
         </StyledNotificationContent>
       </>

--- a/src/features/rewards/walletWrapper/style.ts
+++ b/src/features/rewards/walletWrapper/style.ts
@@ -4,6 +4,8 @@
 
 import { Notification } from './'
 import styled from 'styled-components'
+import Button, { Props as ButtonProps } from '../../../components/buttonsIndicators/button'
+import { ComponentType } from 'react'
 
 interface StyledProps {
   connected?: boolean,
@@ -299,9 +301,15 @@ export const StyledDateText = styled<StyledProps, 'span'>('span')`
   font-family: Muli, sans-serif;
 `
 
-export const StyledButton = styled<StyledProps, 'div'>('div')`
-  width: ${p => p.type === 'backupWallet' ? 101 : 88}px;
-  margin: 12px 122px 15px ${p => p.type === 'backupWallet' ? 123 : 125}px;
+export const StyledButtonWrapper = styled<StyledProps, 'div'>('div')`
+  margin: 12px 0 15px;
+  display: flex;
+  justify-content: center;
+`
+
+export const StyledButton = styled(Button as ComponentType<ButtonProps>)`
+  padding-left: 27px;
+  padding-right: 27px;
 `
 
 export const StyledPipe = styled<StyledProps, 'span'>('span')`

--- a/src/features/rewards/walletWrapper/style.ts
+++ b/src/features/rewards/walletWrapper/style.ts
@@ -13,8 +13,6 @@ interface StyledProps {
   compact?: boolean,
   background?: string,
   isMobile?: boolean,
-  type?: string,
-  onClick?: Function | undefined,
   notification?: Notification | undefined
 }
 
@@ -283,7 +281,6 @@ export const StyledTypeText = styled<StyledProps, 'span'>('span')`
   font-weight: 500;
   margin-right: 5px;
   display: inline-block;
-  cursor: ${p => p.onClick ? 'pointer' : 'default'};
 `
 
 export const StyledMessageText = styled<StyledProps, 'span'>('span')`

--- a/src/features/rewards/walletWrapper/style.ts
+++ b/src/features/rewards/walletWrapper/style.ts
@@ -11,6 +11,8 @@ interface StyledProps {
   compact?: boolean,
   background?: string,
   isMobile?: boolean,
+  type?: string,
+  onClick?: Function | undefined,
   notification?: Notification | undefined
 }
 
@@ -279,6 +281,7 @@ export const StyledTypeText = styled<StyledProps, 'span'>('span')`
   font-weight: 500;
   margin-right: 5px;
   display: inline-block;
+  cursor: ${p => p.onClick ? 'pointer' : 'default'};
 `
 
 export const StyledMessageText = styled<StyledProps, 'span'>('span')`
@@ -297,8 +300,8 @@ export const StyledDateText = styled<StyledProps, 'span'>('span')`
 `
 
 export const StyledButton = styled<StyledProps, 'div'>('div')`
-  width: 88px;
-  margin: 12px 122px 15px 125px;
+  width: ${p => p.type === 'backupWallet' ? 101 : 88}px;
+  margin: 12px 122px 15px ${p => p.type === 'backupWallet' ? 123 : 125}px;
 `
 
 export const StyledPipe = styled<StyledProps, 'span'>('span')`

--- a/stories/assets/locale.ts
+++ b/stories/assets/locale.ts
@@ -17,6 +17,8 @@ const locale: Record<string, string> = {
   amount: 'Amount',
   autoTipText: 'You are automatically sending a tip to:',
   backup: 'Backup',
+  backupNow: 'Backup Now',
+  backupWalletTitle: 'Backup Wallet',
   bat: 'BAT',
   braveAdsDesc: 'No action required. Just collect tokens. Your data is safe with our Shields.',
   braveAdsTitle: 'Brave Ads',

--- a/stories/features/rewards/concepts.tsx
+++ b/stories/features/rewards/concepts.tsx
@@ -321,7 +321,7 @@ storiesOf('Feature Components/Rewards/Concepts/Desktop', module)
             ])}
             grant={store.state.grant}
             onGrantHide={onGrantHide}
-            onFetchCaptcha={onFetchCaptcha}
+            onNotificationClick={onFetchCaptcha}
             onSolution={onSolution}
             onFinish={onFinish}
             convertProbiToFixed={convertProbiToFixed}


### PR DESCRIPTION
## Changes
Related issue: https://github.com/brave/brave-browser/issues/2739
This partially implements changes from this PR: https://github.com/brave/brave-ui/pull/346

This also generalizes the notification action via `onNotificationClick`

## Test plan


##### Link / storybook path to visual changes
https://brave-ui-ql7hj2fsk.now.sh

## Integration
- [ ] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [ ] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [ ] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
