### PR TITLE
Making Rewards panel height dynamic

### DIFF
--- a/src/features/rewards/walletPanel/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/walletPanel/__snapshots__/spec.tsx.snap
@@ -10,6 +10,7 @@ exports[`WalletPanel tests basic tests matches the snapshot 1`] = `
 }
 
 .c1 {
+  min-height: 250px;
   padding: 25px 30px 25px 30px;
 }
 

--- a/src/features/rewards/walletPanel/style.ts
+++ b/src/features/rewards/walletPanel/style.ts
@@ -19,6 +19,7 @@ export const StyledProfileWrapper = styled<{}, 'div'>('div')`
 ` as any
 
 export const StyledContainer = styled<{}, 'div'>('div')`
+  min-height: 250px;
   padding: 25px 30px 25px 30px;
 ` as any
 
@@ -96,6 +97,8 @@ export const StyledNoticeWrapper = styled<StyleProps, 'div'>('div')`
   padding: 10px 12px;
   border-radius: 4px;
   margin: 11px 0 10px;
+  max-height: 84px;
+  overflow-y: scroll;
 `
 
 export const StyledNoticeLink = styled<StyleProps, 'a'>('a')`

--- a/src/features/rewards/walletSummary/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/walletSummary/__snapshots__/spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`WalletSummary tests basic tests matches the snapshot 1`] = `
 .c0 {
-  height: 100%;
+  min-height: 305px;
   padding: 0px;
   background: inherit;
 }

--- a/src/features/rewards/walletSummary/style.ts
+++ b/src/features/rewards/walletSummary/style.ts
@@ -14,7 +14,7 @@ const getGradientRule = (gradient: string) => {
 }
 
 export const StyledWrapper = styled<StyleProps, 'div'>('div')`
-  height: 100%;
+  min-height: 305px;
   padding: ${p => p.compact ? '0px 7px 0px' : '0px'};
   background: ${p => p.compact ? getGradientRule('233, 235, 255') : 'inherit'};
 `

--- a/src/features/rewards/walletSummarySlider/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/walletSummarySlider/__snapshots__/spec.tsx.snap
@@ -5,7 +5,6 @@ exports[`WalletSummarySlider tests basic tests matches the snapshot 1`] = `
   display: block;
   width: 100%;
   height: 100%;
-  position: relative;
 }
 
 <div

--- a/src/features/rewards/walletSummarySlider/index.tsx
+++ b/src/features/rewards/walletSummarySlider/index.tsx
@@ -44,7 +44,11 @@ export default class WalletSummarySlider extends React.PureComponent<
     this.togglePanels = this.togglePanels.bind(this)
   }
 
-  togglePanels (e: any) {
+  togglePanels (showTitle: boolean, e: any) {
+    if (!showTitle && this.state.panelOneShown) {
+      return
+    }
+
     this.setState({
       panelOneShown: !this.state.panelOneShown,
       panelTwoShown: !this.state.panelTwoShown
@@ -59,7 +63,7 @@ export default class WalletSummarySlider extends React.PureComponent<
     return (
       <StyledWrapper>
         {showTitle ? panel : null}
-        <StyledToggleWrapper show={showTitle} onClick={this.togglePanels}>
+        <StyledToggleWrapper show={showTitle} onClick={this.togglePanels.bind(this, showTitle)}>
           <StyledGrid>
             <StyledColumn size={'5'}>
               {showTitle ? (

--- a/src/features/rewards/walletSummarySlider/style.ts
+++ b/src/features/rewards/walletSummarySlider/style.ts
@@ -13,7 +13,6 @@ export const StyledWrapper = styled<{}, 'div'>('div')`
   display: block;
   width: 100%;
   height: 100%;
-  position: relative;
 ` as any
 
 export const StyledTransitionWrapper = styled<StyleProps, 'div'>('div')`
@@ -28,7 +27,7 @@ export const StyledToggleWrapper = styled<StyleProps, 'div'>('div')`
   max-height: 56px;
   padding: ${p => p.show ? '18px 30px 20px 30px' : '20px'};
   top: ${p => p.show ? 'unset' : '12px'};
-  position: absolute;
+  position: ${p => p.show ? 'static' : 'absolute'};
   bottom: ${p => p.show ? '0px' : 'unset'};
   background: ${p => p.show ? '#E9EBFF' : 'inherit'};
 ` as any

--- a/src/features/rewards/walletWrapper/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/walletWrapper/__snapshots__/spec.tsx.snap
@@ -59,7 +59,6 @@ exports[`WalletWrapper tests basic tests matches the snapshot 1`] = `
   -webkit-flex: 1;
   -ms-flex: 1;
   flex: 1;
-  height: 381px;
 }
 
 .c6 {

--- a/src/features/rewards/walletWrapper/style.ts
+++ b/src/features/rewards/walletWrapper/style.ts
@@ -82,7 +82,6 @@ export const StyledContent = styled<StyledProps, 'div'>('div')`
   position: relative;
   background: #f9fbfc;
   flex: 1;
-  height: 381px;
 `
 
 export const StyledAction = styled<{}, 'button'>('button')`

--- a/stories/features/rewards/concepts.tsx
+++ b/stories/features/rewards/concepts.tsx
@@ -332,35 +332,16 @@ storiesOf('Feature Components/Rewards/Concepts/Desktop', module)
             >
               <WalletPanel
                 id={'wallet-panel'}
-                toggleTips={boolean('Toggle tips', true)}
                 platform={'youtube'}
                 publisherImg={bartBaker}
                 publisherName={'Bart Baker'}
                 monthlyAmount={'5.0'}
-                isVerified={true}
+                acEnabled={true}
+                isVerified={boolean('Verified', true)}
+                showUnVerified={boolean('Show Unverified', true)}
                 tipsEnabled={boolean('Tips enabled', store.state.tipsEnabled)}
                 includeInAuto={boolean('Tips enabled', store.state.includeInAuto)}
                 attentionScore={'17'}
-                donationAmounts={
-                  [
-                    {
-                      tokens: '0.0',
-                      converted: '0.00'
-                    },
-                    {
-                      tokens: '1.0',
-                      converted: '0.50'
-                    },
-                    {
-                      tokens: '5.0',
-                      converted: '2.50'
-                    },
-                    {
-                      tokens: '10.0',
-                      converted: '5.00'
-                    }
-                  ]
-                }
                 onToggleTips={onToggleTips}
                 donationAction={doNothing}
                 onAmountChange={doNothing}


### PR DESCRIPTION
Related issue: https://github.com/brave/brave-browser/issues/2874

## Changes
The panel should now accommodate all levels of content.

https://brave-ui-41sbv9idu.now.sh

<img width="458" alt="screen shot 2019-02-13 at 10 54 37 am" src="https://user-images.githubusercontent.com/8732757/52732652-f804ea80-2f7d-11e9-9ae0-6de68d890ac7.png">
<img width="441" alt="screen shot 2019-02-13 at 10 54 33 am" src="https://user-images.githubusercontent.com/8732757/52732654-f804ea80-2f7d-11e9-92df-aca844233d9f.png">
<img width="438" alt="screen shot 2019-02-13 at 10 54 05 am" src="https://user-images.githubusercontent.com/8732757/52732655-f804ea80-2f7d-11e9-94a0-047fc4bcf14e.png">


## Test plan


## Integration
- [ ] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [ ] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [ ] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
