### PR TITLE
update topsite tile click area

### DIFF
--- a/src/features/newTab/default/topSites/index.ts
+++ b/src/features/newTab/default/topSites/index.ts
@@ -97,5 +97,6 @@ export const Tile = styled<TileProps, 'div'>('div')`
 
 export const TileFavicon = styled<{}, 'img'>('img')`
   display: block;
-  height: 40px;
+  height: 72px;
+  padding: 16px;
 `


### PR DESCRIPTION
Addresses https://github.com/brave/brave-browser/issues/3487

The `href` was on the `img` so this just pads the clickable area to assume more of the space of the tile behind the pin and bookmark icons. 