### PR TITLE
Tweak close icons in Rewards setting box

### DIFF
--- a/src/features/rewards/box/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/box/__snapshots__/spec.tsx.snap
@@ -129,13 +129,13 @@ exports[`Box tests basic tests matches the snapshot 1`] = `
   position: absolute;
   right: 29px;
   top: 29px;
-  width: 21px;
-  height: 21px;
+  width: 20px;
+  height: 20px;
   border: none;
   background: none;
   padding: 0;
   cursor: pointer;
-  color: #DFDFE8;
+  color: #585968;
 }
 
 .c14 {
@@ -230,7 +230,10 @@ exports[`Box tests basic tests matches the snapshot 1`] = `
             viewBox="0 0 32 32"
           >
             <path
-              d="M28.71 27.29L17.41 16l11.3-11.29a1 1 0 1 0-1.42-1.42L16 14.59 4.71 3.29a1 1 0 0 0-1.42 1.42L14.59 16 3.29 27.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0L16 17.41l11.29 11.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"
+              d="M16 3a13 13 0 1 0 13 13A13 13 0 0 0 16 3zm0 24a11 11 0 1 1 11-11 11 11 0 0 1-11 11z"
+            />
+            <path
+              d="M20.71 11.29a1 1 0 0 0-1.42 0L16 14.59l-3.29-3.3a1 1 0 0 0-1.42 1.42l3.3 3.29-3.3 3.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l3.29-3.3 3.29 3.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42L17.41 16l3.3-3.29a1 1 0 0 0 0-1.42z"
             />
           </svg>
         </button>

--- a/src/features/rewards/box/index.tsx
+++ b/src/features/rewards/box/index.tsx
@@ -23,7 +23,7 @@ import {
 import { Tooltip } from '../'
 import Toggle from '../../../components/formControls/toggle/index'
 import { getLocale } from '../../../helpers'
-import { CloseStrokeIcon, SettingsIcon } from '../../../components/icons'
+import { CloseCircleOIcon, SettingsIcon } from '../../../components/icons'
 
 export type Type = 'ads' | 'contribute' | 'donation'
 
@@ -119,7 +119,7 @@ export default class Box extends React.PureComponent<Props, {}> {
             </StyledContentWrapper>
             <StyledSettingsWrapper open={settingsOpened}>
               <StyledSettingsClose onClick={onSettingsClick} open={settingsOpened}>
-                <CloseStrokeIcon />
+                <CloseCircleOIcon />
               </StyledSettingsClose>
               <StyledSettingsTitle>
                 <StyledSettingsIcon>

--- a/src/features/rewards/box/style.ts
+++ b/src/features/rewards/box/style.ts
@@ -6,6 +6,7 @@ import styled from 'styled-components'
 import { Type } from './index'
 import Card, { CardProps } from '../../../components/layout/card'
 import { ComponentType } from 'react'
+import palette from '../../../theme/palette'
 
 interface StyleProps {
   open?: boolean
@@ -107,13 +108,13 @@ export const StyledSettingsClose = styled<StyleProps, 'button'>('button')`
   position: absolute;
   right: 29px;
   top: 29px;
-  width: 21px;
-  height: 21px;
+  width: 20px;
+  height: 20px;
   border: none;
   background: none;
   padding: 0;
   cursor: pointer;
-  color: #DFDFE8;
+  color: ${palette.grey600};
 `
 
 export const StyledSettingsTitle = styled<{}, 'div'>('div')`


### PR DESCRIPTION
Addresses: https://github.com/brave/brave-browser/issues/3483

Color matches the other implemented close icons. 

![image](https://user-images.githubusercontent.com/29072694/53604991-f422bc00-3b6a-11e9-9e54-9b728dde7ee7.png)
