### PR TITLE
Update to V4 of styled-components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz",
       "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -164,7 +163,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
       "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
@@ -972,7 +970,6 @@
       "version": "7.3.3",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.3.tgz",
       "integrity": "sha512-2tACZ80Wg09UnPg5uGAOUvvInaqLk3l/IAhQzlxLQOIXacr6bMsra5SH6AWw/hIDRCSbCdHP2KzSOD+cT7TzMQ==",
-      "dev": true,
       "requires": {
         "esutils": "^2.0.2",
         "lodash": "^4.17.11",
@@ -1866,8 +1863,7 @@
     "@types/prop-types": {
       "version": "15.5.9",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.9.tgz",
-      "integrity": "sha512-Nha5b+jmBI271jdTMwrHiNXM+DvThjHOfyZtMX9kj/c/LUj2xiLHsG/1L3tJ8DjAoQN48cHwUwtqBotjyXaSdQ==",
-      "dev": true
+      "integrity": "sha512-Nha5b+jmBI271jdTMwrHiNXM+DvThjHOfyZtMX9kj/c/LUj2xiLHsG/1L3tJ8DjAoQN48cHwUwtqBotjyXaSdQ=="
     },
     "@types/q": {
       "version": "1.5.1",
@@ -1879,7 +1875,6 @@
       "version": "16.8.4",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.4.tgz",
       "integrity": "sha512-Mpz1NNMJvrjf0GcDqiK8+YeOydXfD8Mgag3UtqQ5lXYTsMnOiHcKmO48LiSWMb1rSHB9MV/jlgyNzeAVxWMZRQ==",
-      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
@@ -1900,6 +1895,15 @@
       "integrity": "sha512-MX7n1wq3G/De15RGAAqnmidzhr2Y9O/ClxPxyqaNg96pGyeXUYPSvujgzEVpLo9oIP4Wn1UETl+rxTN02KEpBw==",
       "dev": true,
       "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-native": {
+      "version": "0.57.38",
+      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.57.38.tgz",
+      "integrity": "sha512-bmY2ad/vQgP0HMT7Q7EQzirDBt5ibp+kBHclTnY7/i5MrdqE1oY+3b9NkDg3ohXlumr7p5stAG6I55nhfeUV6Q==",
+      "requires": {
+        "@types/prop-types": "*",
         "@types/react": "*"
       }
     },
@@ -1955,6 +1959,16 @@
       "requires": {
         "@types/react": "*",
         "@types/webpack-env": "*"
+      }
+    },
+    "@types/styled-components": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-4.1.11.tgz",
+      "integrity": "sha512-AMuEwRLqV8T9T7+OV7KnMMODKRxcEAEDGd59pJDFcjx9TTVQmUzBqw7TtNVGh1poxJsm3Iv7SURpgdUr28E7Xw==",
+      "requires": {
+        "@types/react": "*",
+        "@types/react-native": "*",
+        "csstype": "^2.2.0"
       }
     },
     "@types/unist": {
@@ -2592,7 +2606,8 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
     },
     "asn1": {
       "version": "0.2.4",
@@ -3233,6 +3248,17 @@
         "recast": "^0.14.7"
       }
     },
+    "babel-plugin-styled-components": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.0.tgz",
+      "integrity": "sha512-sQVKG8irFXx14ZfaK1bBePirfkacl3j8nZwSZK+ZjsbnadRHKQTbhXbe/RB1vT6Vgkz45E+V95LBq4KqdhZUNw==",
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.0.0",
+        "@babel/helper-module-imports": "^7.0.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "lodash": "^4.17.10"
+      }
+    },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
@@ -3302,8 +3328,7 @@
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
-      "dev": true
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
@@ -4496,7 +4521,8 @@
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+      "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -4820,15 +4846,6 @@
       "dev": true,
       "requires": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
-      "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
-      "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4"
       }
     },
     "buffer-from": {
@@ -6283,7 +6300,8 @@
     "core-js": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -6752,8 +6770,7 @@
     "csstype": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.2.tgz",
-      "integrity": "sha512-Rl7PvTae0pflc1YtxtKbiSqq20Ts6vpIYOD5WBafl4y123DyHUeLrRdQP66sQW8/6gmX8jrYJLXwNeMqYVJcow==",
-      "dev": true
+      "integrity": "sha512-Rl7PvTae0pflc1YtxtKbiSqq20Ts6vpIYOD5WBafl4y123DyHUeLrRdQP66sQW8/6gmX8jrYJLXwNeMqYVJcow=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -7323,6 +7340,7 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
       "requires": {
         "iconv-lite": "~0.4.13"
       }
@@ -7383,13 +7401,12 @@
       }
     },
     "enzyme-adapter-react-16": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.9.1.tgz",
-      "integrity": "sha512-Egzogv1y77DUxdnq/CyHxLHaNxmSSKDDSDNNB/EiAXCZVFXdFibaNy2uUuRQ1n24T2m6KH/1Rw16XDRq+1yVEg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.10.0.tgz",
+      "integrity": "sha512-0QqwEZcBv1xEEla+a3H7FMci+y4ybLia9cZzsdIrId7qcig4MK0kqqf6iiCILH1lsKS6c6AVqL3wGPhCevv5aQ==",
       "dev": true,
       "requires": {
         "enzyme-adapter-utils": "^1.10.0",
-        "function.prototype.name": "^1.1.0",
         "object.assign": "^4.1.0",
         "object.values": "^1.1.0",
         "prop-types": "^15.6.2",
@@ -7681,8 +7698,7 @@
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "etag": {
       "version": "1.8.1",
@@ -8093,6 +8109,7 @@
       "version": "0.8.17",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
       "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+      "dev": true,
       "requires": {
         "core-js": "^1.0.0",
         "isomorphic-fetch": "^2.1.1",
@@ -9512,7 +9529,8 @@
     "has-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
     },
     "has-symbol-support-x": {
       "version": "1.4.2",
@@ -9644,7 +9662,8 @@
     "hoist-non-react-statics": {
       "version": "2.5.5",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
+      "dev": true
     },
     "homedir-polyfill": {
       "version": "1.0.3",
@@ -9845,6 +9864,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -9910,7 +9930,8 @@
     "ieee754": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
+      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
+      "dev": true
     },
     "iferr": {
       "version": "0.1.5",
@@ -10473,7 +10494,8 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-string": {
       "version": "1.0.4",
@@ -10578,6 +10600,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
       "requires": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
@@ -11468,12 +11491,12 @@
       }
     },
     "jest-styled-components": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/jest-styled-components/-/jest-styled-components-5.0.1.tgz",
-      "integrity": "sha512-ZQgTjEZcjWNwADtv+D26MmUUVP2NrAzxCPra5NvflRgiAWaVKt+adHcWRILIyrUo3XfjK1tqiCjS/wjXjeTNGg==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/jest-styled-components/-/jest-styled-components-6.3.1.tgz",
+      "integrity": "sha512-zie3ajvJbwlbHCAq8/Bv5jdbcYCz0ZMRNNX6adL7wSRpkCVPQtiJigv1140JN1ZOJIODPn8VKrjeFCN+jlPa7w==",
       "dev": true,
       "requires": {
-        "css": "^2.2.1"
+        "css": "^2.2.4"
       }
     },
     "jest-util": {
@@ -12283,8 +12306,7 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash-es": {
       "version": "4.17.11",
@@ -13227,6 +13249,7 @@
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dev": true,
       "requires": {
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
@@ -13602,7 +13625,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         }
@@ -15926,6 +15949,7 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
       "requires": {
         "asap": "~2.0.3"
       }
@@ -18729,7 +18753,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "sane": {
       "version": "3.1.0",
@@ -18930,7 +18955,8 @@
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
     },
     "setprototypeof": {
       "version": "1.1.0",
@@ -19682,19 +19708,59 @@
       "dev": true
     },
     "styled-components": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-3.4.10.tgz",
-      "integrity": "sha512-TA8ip8LoILgmSAFd3r326pKtXytUUGu5YWuqZcOQVwVVwB6XqUMn4MHW2IuYJ/HAD81jLrdQed8YWfLSG1LX4Q==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-4.1.3.tgz",
+      "integrity": "sha512-0quV4KnSfvq5iMtT0RzpMGl/Dg3XIxIxOl9eJpiqiq4SrAmR1l1DLzNpMzoy3DyzdXVDMJS2HzROnXscWA3SEw==",
       "requires": {
-        "buffer": "^5.0.3",
-        "css-to-react-native": "^2.0.3",
-        "fbjs": "^0.8.16",
-        "hoist-non-react-statics": "^2.5.0",
+        "@babel/helper-module-imports": "^7.0.0",
+        "@emotion/is-prop-valid": "^0.7.3",
+        "@emotion/unitless": "^0.7.0",
+        "babel-plugin-styled-components": ">= 1",
+        "css-to-react-native": "^2.2.2",
+        "memoize-one": "^4.0.0",
         "prop-types": "^15.5.4",
-        "react-is": "^16.3.1",
+        "react-is": "^16.6.0",
         "stylis": "^3.5.0",
         "stylis-rule-sheet": "^0.0.10",
-        "supports-color": "^3.2.3"
+        "supports-color": "^5.5.0"
+      },
+      "dependencies": {
+        "@emotion/is-prop-valid": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.7.3.tgz",
+          "integrity": "sha512-uxJqm/sqwXw3YPA5GXX365OBcJGFtxUVkB6WyezqFHlNe9jqUWH5ur2O2M8dGBz61kn1g3ZBlzUunFQXQIClhA==",
+          "requires": {
+            "@emotion/memoize": "0.7.1"
+          }
+        },
+        "@emotion/memoize": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.1.tgz",
+          "integrity": "sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg=="
+        },
+        "@emotion/unitless": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.3.tgz",
+          "integrity": "sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg=="
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "memoize-one": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.3.tgz",
+          "integrity": "sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw=="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "stylelint": {
@@ -20004,6 +20070,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
       "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+      "dev": true,
       "requires": {
         "has-flag": "^1.0.0"
       }
@@ -20440,8 +20507,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -20550,12 +20616,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.3.tgz",
       "integrity": "sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw==",
-      "dev": true
-    },
-    "ts-is-kind": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ts-is-kind/-/ts-is-kind-1.0.0.tgz",
-      "integrity": "sha1-+cqcGvB924LXoGdE2JKJUtS9JCY=",
       "dev": true
     },
     "ts-jest": {
@@ -20754,18 +20814,16 @@
       "dev": true
     },
     "typescript-plugin-styled-components": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typescript-plugin-styled-components/-/typescript-plugin-styled-components-0.0.6.tgz",
-      "integrity": "sha1-6EibckNqoXgOhZJDtRkjCyxrU9E=",
-      "dev": true,
-      "requires": {
-        "ts-is-kind": "^1.0.0"
-      }
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typescript-plugin-styled-components/-/typescript-plugin-styled-components-1.2.0.tgz",
+      "integrity": "sha512-nJco2kUnOyiwK+MTkQ05uhrRBxmJPmdjztYKuHYxqntEI6E4S5jMItVv7Dsapq4WGdDgN49/j9bIAx/+s1vHBA==",
+      "dev": true
     },
     "ua-parser-js": {
       "version": "0.7.19",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
-      "integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
+      "integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ==",
+      "dev": true
     },
     "uglify-js": {
       "version": "3.4.9",
@@ -21630,7 +21688,8 @@
     "whatwg-fetch": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
+      "dev": true
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -48,8 +48,9 @@
   },
   "dependencies": {
     "@ctrl/tinycolor": "^2.2.1",
+    "@types/styled-components": "^4.1.10",
     "emptykit.css": "^1.0.1",
-    "styled-components": "^3.2.5"
+    "styled-components": "^4.1.3"
   },
   "devDependencies": {
     "@babel/core": "^7.1.6",
@@ -80,12 +81,12 @@
     "cpr": "^3.0.1",
     "csstype": "^2.5.5",
     "enzyme": "^3.3.0",
-    "enzyme-adapter-react-16": "^1.1.1",
+    "enzyme-adapter-react-16": "^1.10.0",
     "enzyme-to-json": "^3.3.4",
     "fs-extra": "^2.1.2",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^24.1.0",
-    "jest-styled-components": "^5.0.1",
+    "jest-styled-components": "^6.3.1",
     "lerna": "^2.0.0",
     "ncp": "^2.0.0",
     "pre-commit": "^1.2.2",
@@ -94,7 +95,7 @@
     "react-beautiful-dnd": "^10.0.3",
     "react-dom": "^16.3.0",
     "react-storybook-addon-chapters": "^2.1.5",
-    "react-test-renderer": "^16.3.0",
+    "react-test-renderer": "^16.8.3",
     "rimraf": "^2.6.2",
     "storybook-addon-styled-component-theme": "^1.1.1",
     "stylelint": "^9.4.0",
@@ -105,8 +106,8 @@
     "tslint": "^5.8.0",
     "tslint-config-standard": "^7.0.0",
     "tslint-react": "^3.2.0",
-    "typescript": "^3.0.1",
-    "typescript-plugin-styled-components": "0.0.6"
+    "typescript": "^3.3.1",
+    "typescript-plugin-styled-components": "1.2.0"
   },
   "peerDependencies": {
     "react": "^16.0.0"

--- a/src/components/buttonsIndicators/button/__snapshots__/spec.tsx.snap
+++ b/src/components/buttonsIndicators/button/__snapshots__/spec.tsx.snap
@@ -2,9 +2,9 @@
 
 exports[`Button tests basic tests matches the snapshot 1`] = `
 .c0 {
-  --button-main-color: #242536;
-  --button-main-color-hover: #131525;
-  --button-main-color-active: #343546;
+  --button-main-color: #3b3e4f;
+  --button-main-color-hover: #1E2029;
+  --button-main-color-active: #5e6175;
   --button-state-color: var(--button-main-color);
   --icon-size: 16px;
   --icon-spacing: 6px;

--- a/src/components/buttonsIndicators/button/__snapshots__/spec.tsx.snap
+++ b/src/components/buttonsIndicators/button/__snapshots__/spec.tsx.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Button tests basic tests matches the snapshot 1`] = `
-.c1 {
-  --button-main-color: #3b3e4f;
-  --button-main-color-hover: #1E2029;
-  --button-main-color-active: #5e6175;
+.c0 {
+  --button-main-color: #242536;
+  --button-main-color-hover: #131525;
+  --button-main-color-active: #343546;
   --button-state-color: var(--button-main-color);
   --icon-size: 16px;
   --icon-spacing: 6px;
@@ -39,23 +39,20 @@ exports[`Button tests basic tests matches the snapshot 1`] = `
   width: auto;
   min-width: 104px;
   padding: 11px 15px;
-}
-
-.c1:hover:enabled {
-  --button-state-color: var(--button-main-color-hover);
-}
-
-.c1:active:enabled {
-  --button-state-color: var(--button-main-color-active);
-}
-
-.c0 {
   color: #fff;
   background: var(--button-state-color);
   border: 1px solid var(--button-state-color);
 }
 
-.c2 {
+.c0:hover:enabled {
+  --button-state-color: var(--button-main-color-hover);
+}
+
+.c0:active:enabled {
+  --button-state-color: var(--button-main-color-active);
+}
+
+.c1 {
   min-height: var(--icon-size);
   display: -webkit-box;
   display: -webkit-flex;
@@ -76,13 +73,13 @@ exports[`Button tests basic tests matches the snapshot 1`] = `
 }
 
 <button
-  className="c0 c1"
+  className="c0"
   id="button"
   size="medium"
   type="default"
 >
   <div
-    className="c2"
+    className="c1"
     id="button"
     size="medium"
     type="default"

--- a/src/components/buttonsIndicators/button/style.ts
+++ b/src/components/buttonsIndicators/button/style.ts
@@ -63,7 +63,7 @@ const getThemeColors = (p: ThemedStyledProps<Props>) => {
   `
 }
 
-const StyledButton = styled<Props, 'button'>('button')`
+const StyledButton = styled.button<Props>`
   ${getThemeColors}
   --button-state-color: var(--button-main-color);
   --icon-size: ${largeMediumSmall('18px', '16px', '14px')};
@@ -110,7 +110,7 @@ export const TertiaryButton = styled(StyledButton)`
   color: var(--button-state-color);
 `
 
-export const StyledText = styled<Props, 'div'>('div')`
+export const StyledText = styled.div<Props>`
   /* min-height so that we get consistent height with / without an icon */
   min-height: var(--icon-size);
   display: flex;
@@ -122,7 +122,7 @@ export const StyledText = styled<Props, 'div'>('div')`
   line-height: 1;
 `
 
-export const StyledIcon = styled<Props, 'div'>('div')`
+export const StyledIcon = styled.div<Props>`
   display: block;
   line-height: 0;
   height: var(--icon-size);

--- a/src/components/dataTables/table/style.ts
+++ b/src/components/dataTables/table/style.ts
@@ -5,19 +5,19 @@
 import styled, { css } from 'styled-components'
 import { Cell, Row } from './index'
 
-export const StyledNoContent = styled<{}, 'div'>('div')`
+export const StyledNoContent = styled.div`
   text-align: center;
   padding: 30px 0;
   color: #999ea2;
   font-size: 14px;
 `
 
-export const StyledTable = styled<{}, 'table'>('table')`
+export const StyledTable = styled.table`
   width: 100%;
   margin-bottom: 20px;
 `
 
-export const StyledTH = styled<Partial<Cell>, 'th'>('th')`
+export const StyledTH = styled.th<Partial<Cell>>`
   text-transform: uppercase;
   text-align: left;
   font-family: Poppins, sans-serif;
@@ -37,7 +37,7 @@ export const StyledTH = styled<Partial<Cell>, 'th'>('th')`
   };
 `
 
-export const StyledTR = styled<Partial<Row>, 'tr'>('tr')`
+export const StyledTR = styled.tr<Partial<Row>>`
   ${p => p.customStyle
     ? css`
       ${p.customStyle}
@@ -46,7 +46,7 @@ export const StyledTR = styled<Partial<Row>, 'tr'>('tr')`
   };
 `
 
-export const StyledTD = styled<Partial<Cell>, 'td'>('td')`
+export const StyledTD = styled.td<Partial<Cell>>`
   font-family: Muli, sans-serif;
   font-size: 14px;
   font-weight: 500;

--- a/src/components/formControls/checkbox/style.ts
+++ b/src/components/formControls/checkbox/style.ts
@@ -56,7 +56,7 @@ const getLabel = (p: Partial<StyleProps>) => {
   `
 }
 
-export const StyledLabel = styled<Partial<StyleProps>, 'div'>('div')`
+export const StyledLabel = styled.div<Partial<StyleProps>>`
   font-family: Poppins, sans-serif;
   line-height: 1.3;
   display: flex;
@@ -67,7 +67,7 @@ export const StyledLabel = styled<Partial<StyleProps>, 'div'>('div')`
   cursor: pointer;
 `
 
-export const StyledBox = styled<Partial<StyleProps>, 'span'>('span')`
+export const StyledBox = styled.span<Partial<StyleProps>>`
   border-radius: 2px;
   text-align: center;
   display: flex;
@@ -83,7 +83,7 @@ export const StyledBox = styled<Partial<StyleProps>, 'span'>('span')`
   margin-right: var(--checkbox-box-spacing);
 `
 
-export const StyledText = styled<Partial<StyleProps>, 'span'>('span')`
+export const StyledText = styled.span<Partial<StyleProps>>`
   flex: 1;
   padding-top: ${(p) => p.size === 'big' ? '2px' : '1px'};
   letter-spacing: 0;

--- a/src/components/formControls/controlWrapper/style.ts
+++ b/src/components/formControls/controlWrapper/style.ts
@@ -25,12 +25,12 @@ const getColor = (p: Partial<Props>) => {
   `
 }
 
-export const StyledWrapper = styled<{}, 'div'>('div')`
+export const StyledWrapper = styled.div`
   width: 100%;
   margin-bottom: 12px;
 `
 
-export const StyledLabel = styled<Partial<Props>, 'div'>('div')`
+export const StyledLabel = styled.div<Partial<Props>>`
   width: 100%;
   font-family: Poppins, sans-serif;
   line-height: normal;

--- a/src/components/formControls/input/style.ts
+++ b/src/components/formControls/input/style.ts
@@ -6,7 +6,7 @@ import styled from 'styled-components'
 import theme from '../../../theme/brave-default'
 import { InputProps } from './index'
 
-export const InputComponent = styled<InputProps, 'div'>('div')`
+export const InputComponent = styled.div<InputProps>`
   background-color: #fff;
   min-height: auto;
   box-sizing: border-box;
@@ -20,7 +20,7 @@ export const InputComponent = styled<InputProps, 'div'>('div')`
   }
 `
 
-export const StyledIcon = styled<{}, 'div'>('div')`
+export const StyledIcon = styled.div`
   display: inline-block;
   vertical-align: middle;
   width: 20px;
@@ -28,7 +28,7 @@ export const StyledIcon = styled<{}, 'div'>('div')`
   color: #D1D1DB;
 `
 
-export const StyledInput = styled<InputProps, 'input'>('input')`
+export const StyledInput = styled.input<InputProps>`
   display: inline-block;
   vertical-align: middle;
   min-height: auto;

--- a/src/components/formControls/radio/style.ts
+++ b/src/components/formControls/radio/style.ts
@@ -47,7 +47,7 @@ const getThemeColors = (p: ThemedStyledProps<StyleProps>, selected: boolean | un
   `
 }
 
-export const StyledLabel = styled<StyleProps, 'label'>('label')`
+export const StyledLabel = styled.label<StyleProps>`
   ${p => getThemeSizes(p)}
   line-height: 1.3;
   display: flex;
@@ -56,12 +56,12 @@ export const StyledLabel = styled<StyleProps, 'label'>('label')`
   cursor: pointer;
 `
 
-export const StyledInput = styled<{}, 'input'>('input')`
+export const StyledInput = styled.input`
   opacity: 0;
   position: absolute;
 `
 
-export const StyledCircle = styled<StyleProps, 'span'>('span')`
+export const StyledCircle = styled.span<StyleProps>`
   ${p => getThemeSizes(p)}
   ${p => getThemeColors(p, p.selected)}
   text-align: center;
@@ -76,7 +76,7 @@ export const StyledCircle = styled<StyleProps, 'span'>('span')`
   border-radius: 50%;
 `
 
-export const StyledFill = styled<StyleProps, 'div'>('div')`
+export const StyledFill = styled.div<StyleProps>`
   ${p => getThemeSizes(p)}
   ${p => getThemeColors(p, p.selected)}
   width: var(--radio-fill-size);
@@ -85,7 +85,7 @@ export const StyledFill = styled<StyleProps, 'div'>('div')`
   background: var(--radio-fill-color);
 `
 
-export const StyledText = styled<StyleProps, 'span'>('span')`
+export const StyledText = styled.span<StyleProps>`
   flex: 1;
   letter-spacing: 0;
   display: flex;

--- a/src/components/formControls/select/__snapshots__/spec.tsx.snap
+++ b/src/components/formControls/select/__snapshots__/spec.tsx.snap
@@ -53,7 +53,7 @@ exports[`Select tests basic tests matches the snapshot 1`] = `
   text-overflow: ellipsis;
 }
 
-.c7 {
+.c6 {
   position: absolute;
   top: calc(100% + 4px);
   left: 0;
@@ -68,7 +68,7 @@ exports[`Select tests basic tests matches the snapshot 1`] = `
   padding: 9px 0;
 }
 
-.c8 {
+.c7 {
   font-size: 14px;
   line-height: 36px;
   color: #1b1d2f;
@@ -81,7 +81,7 @@ exports[`Select tests basic tests matches the snapshot 1`] = `
   background: #e9f0ff;
 }
 
-.c12 {
+.c11 {
   font-size: 14px;
   line-height: 36px;
   color: #1b1d2f;
@@ -94,7 +94,7 @@ exports[`Select tests basic tests matches the snapshot 1`] = `
   background: #fff;
 }
 
-.c9 {
+.c8 {
   -webkit-flex-basis: 11px;
   -ms-flex-preferred-size: 11px;
   flex-basis: 11px;
@@ -112,7 +112,7 @@ exports[`Select tests basic tests matches the snapshot 1`] = `
   color: #A1A8F2;
 }
 
-.c11 {
+.c10 {
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
@@ -123,19 +123,16 @@ exports[`Select tests basic tests matches the snapshot 1`] = `
   text-overflow: ellipsis;
 }
 
-.c6 {
+.c5 {
   width: 100%;
   height: 100%;
   fill: currentColor;
-}
-
-.c5 {
   -webkit-transform: rotate(-90deg);
   -ms-transform: rotate(-90deg);
   transform: rotate(-90deg);
 }
 
-.c10 {
+.c9 {
   width: 100%;
   height: 100%;
   fill: currentColor;
@@ -165,7 +162,7 @@ exports[`Select tests basic tests matches the snapshot 1`] = `
       >
         <svg
           aria-hidden="true"
-          className="c5 c6"
+          className="c5"
           focusable="false"
           viewBox="0 0 32 32"
         >
@@ -176,19 +173,19 @@ exports[`Select tests basic tests matches the snapshot 1`] = `
       </div>
     </div>
     <div
-      className="c7"
+      className="c6"
     >
       <div
-        className="c8"
+        className="c7"
         onClick={[Function]}
         selected={true}
       >
         <div
-          className="c9"
+          className="c8"
         >
           <svg
             aria-hidden="true"
-            className="c10"
+            className="c9"
             focusable="false"
             viewBox="0 0 32 32"
           >
@@ -198,35 +195,35 @@ exports[`Select tests basic tests matches the snapshot 1`] = `
           </svg>
         </div>
         <div
-          className="c11"
+          className="c10"
         >
           01
         </div>
       </div>
       <div
-        className="c12"
+        className="c11"
         onClick={[Function]}
         selected={false}
       >
         <div
-          className="c9"
+          className="c8"
         />
         <div
-          className="c11"
+          className="c10"
         >
           11
         </div>
       </div>
       <div
-        className="c12"
+        className="c11"
         onClick={[Function]}
         selected={false}
       >
         <div
-          className="c9"
+          className="c8"
         />
         <div
-          className="c11"
+          className="c10"
         >
           12
         </div>

--- a/src/components/formControls/select/style.ts
+++ b/src/components/formControls/select/style.ts
@@ -45,17 +45,17 @@ interface StyleProps extends Props {
   showAllContents?: boolean
 }
 
-export const StyledWrapper = styled<StyleProps, 'div'>('div')`
+export const StyledWrapper = styled.div<StyleProps>`
   width: 100%;
 `
 
-export const StyledSelectWrapper = styled<StyleProps, 'div'>('div')`
+export const StyledSelectWrapper = styled.div<StyleProps>`
   position: relative;
   outline: 0;
   font-family: Muli, sans-serif;
 `
 
-export const StyledSelect = styled<StyleProps, 'div'>('div')`
+export const StyledSelect = styled.div<StyleProps>`
   border-radius: 3px;
   font-size: 14px;
   width: 100%;
@@ -67,7 +67,7 @@ export const StyledSelect = styled<StyleProps, 'div'>('div')`
   border: var(--select-select-border);
 `
 
-export const StyledSelectArrow = styled<StyleProps, 'div'>('div')`
+export const StyledSelectArrow = styled.div<StyleProps>`
   margin-right: ${p => p.floating ? -9 : 15}px;
   flex-basis: 33px;
   flex-shrink: 0;
@@ -75,7 +75,7 @@ export const StyledSelectArrow = styled<StyleProps, 'div'>('div')`
   margin-top: ${p => p.floating ? -5 : 0}px;
 `
 
-export const StyledSelectText = styled<StyleProps, 'div'>('div')`
+export const StyledSelectText = styled.div<StyleProps>`
   flex-grow: 1;
   padding: ${p => p.floating ? 0 : '0 5px 0 13px'};
   overflow: hidden;
@@ -83,7 +83,7 @@ export const StyledSelectText = styled<StyleProps, 'div'>('div')`
   text-overflow: ellipsis;
 `
 
-export const StyledOptions = styled<StyleProps, 'div'>('div')`
+export const StyledOptions = styled.div<StyleProps>`
   position: absolute;
   top: calc(100% + 4px);
   left: 0;
@@ -98,7 +98,7 @@ export const StyledOptions = styled<StyleProps, 'div'>('div')`
   padding: 9px 0;
 `
 
-export const StyledOption = styled<StyleProps, 'div'>('div')`
+export const StyledOption = styled.div<StyleProps>`
   font-size: 14px;
   line-height: 36px;
   color: #1b1d2f;
@@ -108,7 +108,7 @@ export const StyledOption = styled<StyleProps, 'div'>('div')`
   background: ${p => p.selected ? '#e9f0ff' : '#fff'};
 `
 
-export const StyledOptionCheck = styled<StyleProps, 'div'>('div')`
+export const StyledOptionCheck = styled.div<StyleProps>`
   flex-basis: 11px;
   flex-shrink: 0;
   display: flex;
@@ -116,7 +116,7 @@ export const StyledOptionCheck = styled<StyleProps, 'div'>('div')`
   color: #A1A8F2;
 `
 
-export const StyledOptionText = styled<StyleProps, 'div'>('div')`
+export const StyledOptionText = styled.div<StyleProps>`
   flex-grow: 1;
   padding: 0 21px 0 6px;
   overflow: hidden;
@@ -124,7 +124,7 @@ export const StyledOptionText = styled<StyleProps, 'div'>('div')`
   text-overflow: ${p => p.showAllContents ? 'initial' : 'ellipsis'};
 `
 
-export const StyledOptionsOverlay = styled<StyleProps, 'div'>('div')`
+export const StyledOptionsOverlay = styled.div<StyleProps>`
   display: flex;
   position: fixed;
   top: 0;
@@ -137,7 +137,7 @@ export const StyledOptionsOverlay = styled<StyleProps, 'div'>('div')`
   justify-content: center;
 `
 
-export const StyledOptionsModal = styled<StyleProps, 'div'>('div')`
+export const StyledOptionsModal = styled.div<StyleProps>`
   border-radius: 7px;
   background: ${p => p.theme.color.primaryBackground};
   height: 30%;
@@ -162,7 +162,7 @@ export const StyledOptionsModal = styled<StyleProps, 'div'>('div')`
   }
 `
 
-export const StyledSelectTitle = styled<StyleProps, 'span'>('span')`
+export const StyledSelectTitle = styled.span<StyleProps>`
   color: ${p => p.theme.color.defaultControlActive};
   display: block;
   font-size: 16px;
@@ -173,11 +173,11 @@ export const StyledSelectTitle = styled<StyleProps, 'span'>('span')`
   text-align: left;
 `
 
-export const StyledModalContent = styled<StyleProps, 'div'>('div')`
+export const StyledModalContent = styled.div<StyleProps>`
   display: block;
 `
 
-export const StyledRadioOptions = styled<StyleProps, 'div'>('div')`
+export const StyledRadioOptions = styled.div<StyleProps>`
   display: block;
   max-height: 250px;
   overflow-y: scroll;

--- a/src/components/formControls/textarea/style.ts
+++ b/src/components/formControls/textarea/style.ts
@@ -19,11 +19,11 @@ const getBorder = (p: Props) => {
   return color
 }
 
-export const StyledWrapper = styled<{}, 'div'>('div')`
+export const StyledWrapper = styled.div`
   width: 100%;
 `
 
-export const StyledArea = styled<Props, 'textarea'>('textarea')`
+export const StyledArea = styled.textarea<Props>`
   min-height: 140px;
   box-sizing: border-box;
   width: 100%;

--- a/src/components/formControls/textareaClipboard/style.ts
+++ b/src/components/formControls/textareaClipboard/style.ts
@@ -5,7 +5,7 @@
 import styled, { keyframes, css } from 'styled-components'
 import { Props } from './index'
 
-export const StyledWrapper = styled<{}, 'div'>('div')`
+export const StyledWrapper = styled.div`
   width: 100%;
   padding: 10px;
   border: 1px solid #DFDFE8;
@@ -18,7 +18,7 @@ export const StyledWrapper = styled<{}, 'div'>('div')`
   }
 `
 
-export const StyledArea = styled<Props, 'textarea'>('textarea')`
+export const StyledArea = styled.textarea<Props>`
   min-height: 140px;
   box-sizing: border-box;
   width: 100%;
@@ -39,7 +39,7 @@ export const StyledArea = styled<Props, 'textarea'>('textarea')`
     outline: none;
   }
 `
-export const StyledFooter = styled<{}, 'div'>('div')`
+export const StyledFooter = styled.div`
   display: grid;
   grid-template-columns: 1fr auto;
   grid-template-rows: auto;
@@ -63,7 +63,7 @@ interface StyledTextProps {
   visible?: boolean
 }
 
-export const StyledText = styled<StyledTextProps, 'span'>('span')`
+export const StyledText = styled.span<StyledTextProps>`
   opacity: 0;
 
 ${p => p.visible && css`
@@ -74,7 +74,7 @@ ${p => p.visible && css`
   `}
 `
 
-export const StyledCopyToClipboard = styled<{}, 'div'>('div')`
+export const StyledCopyToClipboard = styled.div`
   display: grid;
   grid-template-columns: auto auto;
   grid-template-rows: auto;
@@ -82,7 +82,7 @@ export const StyledCopyToClipboard = styled<{}, 'div'>('div')`
   align-items: center;
 `
 
-export const StyledClipboardButton = styled<{}, 'button'>('button')`
+export const StyledClipboardButton = styled.button`
   width: 24px;
   height: 24px;
   padding: 0;

--- a/src/components/formControls/toggle/style.ts
+++ b/src/components/formControls/toggle/style.ts
@@ -38,11 +38,11 @@ const getBulletStyle = (p: Props) => {
   `
 }
 
-export const StyledWrapper = styled<Props, 'div'>('div')`
+export const StyledWrapper = styled.div<Props>`
   display: flex;
 `
 
-export const StyleToggle = styled<Props, 'div'>('div')`
+export const StyleToggle = styled.div<Props>`
   position: relative;
   display: block;
   height: ${(p) => p.size === 'small' ? '16px' : '24px'};
@@ -56,7 +56,7 @@ export const StyleToggle = styled<Props, 'div'>('div')`
   };
 `
 
-export const StyledSlider = styled<Props, 'div'>('div')`
+export const StyledSlider = styled.div<Props>`
   background: ${(p) => p.disabled ? '#F6F6FA' : '#A7ACB2'};
   height: ${(p) => p.size === 'small' ? '6px' : '8px'};
   margin-top: ${(p) => p.size === 'small' ? '5px' : '8px'};
@@ -64,7 +64,7 @@ export const StyledSlider = styled<Props, 'div'>('div')`
   border-radius: 3px;
 `
 
-export const StyledBullet = styled<Props, 'div'>('div')`
+export const StyledBullet = styled.div<Props>`
   position: relative;
   border-radius: 50%;
   transition: all .4s ease;
@@ -76,7 +76,7 @@ export const StyledBullet = styled<Props, 'div'>('div')`
   box-shadow: 0 3px 3px rgba(0,0,0,0.05);
 `
 
-export const StyledText = styled<Props, 'div'>('div')`
+export const StyledText = styled.div<Props>`
   color: #838391;
   font-size: ${(p) => p.size === 'small' ? '12px' : '14px'};
   font-family: Poppins, sans-serif;

--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -1,4 +1,4 @@
-import styled, { StyledComponentClass } from 'styled-components'
+import styled, { StyledComponentBase } from 'styled-components'
 // rotated imports
 import ArrowIcon from './arrow'
 import CaratIcon from './carat'
@@ -7,7 +7,7 @@ import CaratCircleIcon from './carat-circle'
 
 // rotated variants
 function RotatedIconComponent (
-  iconComponent: StyledComponentClass<any, any>,
+  iconComponent: StyledComponentBase<any, any>,
   degrees: number
 ) {
   return styled(iconComponent)`

--- a/src/components/layout/card/style.ts
+++ b/src/components/layout/card/style.ts
@@ -5,7 +5,7 @@
 import styled from 'styled-components'
 import { CardProps } from './index'
 
-export const StyledCard = styled<CardProps, 'div'>('div')`
+export const StyledCard = styled.div<CardProps>`
   max-width: 100%;
   width: 100%;
   min-height: auto;

--- a/src/components/layout/gridList/style.ts
+++ b/src/components/layout/gridList/style.ts
@@ -6,7 +6,7 @@ import styled, { css } from 'styled-components'
 import { GridProps, ColumnProps } from './index'
 import { setTheme } from '../../../helpers'
 
-export const StyledGrid = styled<GridProps, 'div'>('div')`
+export const StyledGrid = styled.div<GridProps>`
   box-sizing: border-box;
   display: grid;
   grid-template-columns: repeat(${p => p.columns ? p.columns : '12'}, 1fr);
@@ -29,7 +29,7 @@ export const StyledGrid = styled<GridProps, 'div'>('div')`
   }
 `
 
-export const StyledColumn = styled<ColumnProps, 'div'>('div')`
+export const StyledColumn = styled.div<ColumnProps>`
   box-sizing: border-box;
   position: relative;
   display: flex;

--- a/src/components/layout/tabs/style.ts
+++ b/src/components/layout/tabs/style.ts
@@ -8,13 +8,13 @@ interface StyleProps {
   selected: boolean
 }
 
-export const StyledTabWrapper = styled<{}, 'div'>('div')`
+export const StyledTabWrapper = styled.div`
   border-bottom: 1px solid #DFDFE8;
   text-align: center;
   font-family: Poppins, sans-serif;
 `
 
-export const StyledTab = styled<StyleProps, 'div'>('div')`
+export const StyledTab = styled.div<StyleProps>`
   border-radius: 6px 6px 0 0;
   border: 1px solid #DFDFE8;
   border-bottom: 1px solid ${p => p.selected ? '#FFF' : '#DFDFE8'};
@@ -32,6 +32,6 @@ export const StyledTab = styled<StyleProps, 'div'>('div')`
   top: 1px
 `
 
-export const StyledContent = styled<{}, 'div'>('div')`
+export const StyledContent = styled.div`
   padding: 34px 56px 20px;
 `

--- a/src/components/popupModals/alertBox/style.ts
+++ b/src/components/popupModals/alertBox/style.ts
@@ -4,7 +4,7 @@
 
 import styled from 'styled-components'
 
-export const StyledDialogWrapper = styled<{}, 'div'>('div')`
+export const StyledDialogWrapper = styled.div`
   position: absolute;
   top: 0;
   left: 0;
@@ -14,7 +14,7 @@ export const StyledDialogWrapper = styled<{}, 'div'>('div')`
   display: flex;
 `
 
-export const StyledDialog = styled<{}, 'div'>('div')`
+export const StyledDialog = styled.div`
   width: 470px;
   margin: auto;
   padding: 30px 20px 10px;
@@ -27,13 +27,13 @@ export const StyledDialog = styled<{}, 'div'>('div')`
   border-radius: 6px;
 `
 
-export const StyledFooter = styled<{}, 'footer'>('footer')`
+export const StyledFooter = styled.footer`
   display: grid;
   grid-template-columns: 1fr auto;
   grid-gap: 10px;
 `
 
-export const StyledCancelContainer = styled<{}, 'div'>('div')`
+export const StyledCancelContainer = styled.div`
   display: flex;
   justify-content: flex-end;
 `

--- a/src/components/popupModals/modal/style.ts
+++ b/src/components/popupModals/modal/style.ts
@@ -26,7 +26,7 @@ const getHeightOffset = (isMobile?: boolean, isLandscape?: boolean) => {
   return 0
 }
 
-export const StyledWrapper = styled<{}, 'div'>('div')`
+export const StyledWrapper = styled.div`
   position: fixed;
   top: 0;
   left: 0;
@@ -38,7 +38,7 @@ export const StyledWrapper = styled<{}, 'div'>('div')`
   overflow: hidden;
 `
 
-export const StyledDialog = styled<Props, 'div'>('div')`
+export const StyledDialog = styled.div<Props>`
   max-width: ${p => p.size === 'small' ? '666px' : '920px'};
   margin: 52px auto;
   background: #fff;
@@ -47,7 +47,7 @@ export const StyledDialog = styled<Props, 'div'>('div')`
   position: relative;
 `
 
-export const StyledClose = styled<{}, 'div'>('div')`
+export const StyledClose = styled.div`
   position: absolute;
   top: 20px;
   right: 20px;
@@ -57,7 +57,7 @@ export const StyledClose = styled<{}, 'div'>('div')`
   color: #9E9FAB;
 `
 
-export const StyledContent = styled<StyleProps, 'div'>('div')`
+export const StyledContent = styled.div<StyleProps>`
   padding: 48px 48px;
   overflow-y: auto;
   max-height: calc(100vh - ${p => getHeightOffset(p.isMobile, p.isLandscape)}px);

--- a/src/components/text/heading/__snapshots__/spec.tsx.snap
+++ b/src/components/text/heading/__snapshots__/spec.tsx.snap
@@ -1,20 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`all heading tests heading tests basic tests matches the snapshot 1`] = `
-.c1 {
+.c0 {
   box-sizing: border-box;
   font-family: Poppins,sans-serif;
   font-weight: 400;
   -webkit-font-smoothing: antialiased;
   margin: 0;
-}
-
-.c0 {
   font-size: 48px;
 }
 
 <h1
-  className="c0 c1"
+  className="c0"
   data-test-id="testHeading"
 />
 `;

--- a/src/components/text/heading/style.ts
+++ b/src/components/text/heading/style.ts
@@ -6,7 +6,7 @@ import styled from 'styled-components'
 import { HeadingProps } from './index'
 import theme from '../../../theme/brave-default'
 
-const StyledSharedHeading = styled<HeadingProps, 'span'>('span')`
+const StyledSharedHeading = styled.span<HeadingProps>`
   box-sizing: border-box;
   font-family: ${theme.fontFamily.heading};
   font-weight: 400;

--- a/src/features/newTab/default/clock/style.ts
+++ b/src/features/newTab/default/clock/style.ts
@@ -4,7 +4,7 @@
 
 import styled from 'styled-components'
 
-export const StyledClock = styled<{}, 'div'>('div')`
+export const StyledClock = styled.div`
   color: #FFFFFF;
   box-sizing: border-box;
   line-height: 1;
@@ -14,7 +14,7 @@ export const StyledClock = styled<{}, 'div'>('div')`
   font-family: ${p => p.theme.fontFamily.heading};
 `
 
-export const StyledTime = styled<{}, 'span'>('span')`
+export const StyledTime = styled.span`
   box-sizing: border-box;
   font-size: 90px;
   font-weight: 200;
@@ -22,7 +22,7 @@ export const StyledTime = styled<{}, 'span'>('span')`
   display: inline-flex;
 `
 
-export const StyledTimeSeparator = styled<{}, 'span'>('span')`
+export const StyledTimeSeparator = styled.span`
   box-sizing: border-box;
   color: inherit;
   font-size: inherit;

--- a/src/features/newTab/default/grid/index.ts
+++ b/src/features/newTab/default/grid/index.ts
@@ -4,7 +4,7 @@
 
 import styled from '../../../../theme'
 
-export const Header = styled<{}, 'header'>('header')`
+export const Header = styled.header`
   box-sizing: border-box;
   display: grid;
   height: 100%;
@@ -52,11 +52,11 @@ export const Header = styled<{}, 'header'>('header')`
   }
 `
 
-export const Main = styled<{}, 'main'>('main')`
+export const Main = styled.main`
   box-sizing: border-box;
 `
 
-export const Footer = styled<{}, 'footer'>('footer')`
+export const Footer = styled.footer`
   box-sizing: border-box;
   display: grid;
   height: 100%;

--- a/src/features/newTab/default/notification/index.ts
+++ b/src/features/newTab/default/notification/index.ts
@@ -4,7 +4,7 @@
 
 import styled from '../../../../theme'
 
-export const SiteRemovalNotification = styled<{}, 'header'>('header')`
+export const SiteRemovalNotification = styled.header`
   font-family: ${p => p.theme.fontFamily.heading};
   border-radius: 8px;
   box-shadow: 2px 2px 6px rgba(0,0,0,0.3);
@@ -18,7 +18,7 @@ export const SiteRemovalNotification = styled<{}, 'header'>('header')`
   justify-content: space-between;
 `
 
-export const SiteRemovalText = styled<{}, 'span'>('span')`
+export const SiteRemovalText = styled.span`
   box-sizing: border-box;
   user-select: none;
   font-size: 18px;
@@ -28,7 +28,7 @@ interface SiteRemovalActionProps {
   iconOnly?: boolean
 }
 
-export const SiteRemovalAction = styled<SiteRemovalActionProps, 'a'>('a')`
+export const SiteRemovalAction = styled.a<SiteRemovalActionProps>`
   font-size: 16px;
   cursor: pointer;
   color: #fb542b;

--- a/src/features/newTab/default/page/index.ts
+++ b/src/features/newTab/default/page/index.ts
@@ -13,7 +13,7 @@ const fadeIn = keyframes`
   }
 `
 
-export const Page = styled<{}, 'div'>('div')`
+export const Page = styled.div`
   -webkit-font-smoothing: antialiased;
   box-sizing: border-box;
   position: relative;
@@ -32,7 +32,7 @@ interface DynamicBackgroundProps {
   background: string
 }
 
-export const DynamicBackground = styled<DynamicBackgroundProps, 'div'>('div')`
+export const DynamicBackground = styled.div<DynamicBackgroundProps>`
   box-sizing: border-box;
   background-position: top center;
   background-repeat: no-repeat;
@@ -45,7 +45,7 @@ export const DynamicBackground = styled<DynamicBackgroundProps, 'div'>('div')`
   animation-fill-mode: forwards;
 `
 
-export const Gradient = styled<{}, 'div'>('div')`
+export const Gradient = styled.div`
   position: absolute;
   top: 0;
   left: 0;
@@ -59,7 +59,7 @@ export const Gradient = styled<{}, 'div'>('div')`
   height: 100vh;
 `
 
-export const Link = styled<{}, 'a'>('a')`
+export const Link = styled.a`
   text-decoration: none;
   transition: color 0.15s ease, filter 0.15s ease;
   color: rgba(255, 255, 255, 0.8);
@@ -69,7 +69,7 @@ export const Link = styled<{}, 'a'>('a')`
   }
 `
 
-export const PhotoName = styled<{}, 'div'>('div')`
+export const PhotoName = styled.div`
   -webkit-font-smoothing: antialiased;
   box-sizing: border-box;
   font-size: 12px;
@@ -77,11 +77,11 @@ export const PhotoName = styled<{}, 'div'>('div')`
   color: rgba(255, 255, 255, 0.6);
 `
 
-export const Navigation = styled<{}, 'nav'>('nav')`
+export const Navigation = styled.nav`
   display: flex;
 `
 
-export const IconLink = styled<{}, 'a'>('a')`
+export const IconLink = styled.a`
   display: flex;
   width: 24px;
   height: 24px;

--- a/src/features/newTab/default/stats/style.ts
+++ b/src/features/newTab/default/stats/style.ts
@@ -4,7 +4,7 @@
 
 import styled from '../../../../theme'
 
-export const StyledStatsItemContainer = styled<{}, 'ul'>('ul')`
+export const StyledStatsItemContainer = styled.ul`
   -webkit-font-smoothing: antialiased;
   display: grid;
   grid-template-columns: repeat(4, fit-content(100%));
@@ -26,7 +26,7 @@ export const StyledStatsItemContainer = styled<{}, 'ul'>('ul')`
   }
 `
 
-export const StyledStatsItem = styled<{}, 'li'>('li')`
+export const StyledStatsItem = styled.li`
   list-style-type: none;
   font-size: inherit;
   font-family: inherit;
@@ -45,7 +45,7 @@ export const StyledStatsItem = styled<{}, 'li'>('li')`
   }
 `
 
-export const StyledStatsItemCounter = styled<{}, 'span'>('span')`
+export const StyledStatsItemCounter = styled.span`
   color: inherit;
   font-family: ${p => p.theme.fontFamily.heading};
   font-size: 46px;
@@ -56,7 +56,7 @@ export const StyledStatsItemCounter = styled<{}, 'span'>('span')`
   overflow: hidden;
 `
 
-export const StyledStatsItemText = styled<{}, 'span'>('span')`
+export const StyledStatsItemText = styled.span`
   font-size: 20px;
   font-family: ${p => p.theme.fontFamily.heading};
   margin-left: 4px;
@@ -64,7 +64,7 @@ export const StyledStatsItemText = styled<{}, 'span'>('span')`
   letter-spacing: 0;
 `
 
-export const StyledStatsItemDescription = styled<{}, 'div'>('div')`
+export const StyledStatsItemDescription = styled.div`
   font-size: 14px;
   font-weight: 400;
   color: #FFFFFF;

--- a/src/features/newTab/default/topSites/index.ts
+++ b/src/features/newTab/default/topSites/index.ts
@@ -4,7 +4,7 @@
 
 import styled from '../../../../theme'
 
-export const List = styled<{}, 'div'>('div')`
+export const List = styled.div`
   padding: 0 70px;
   height: 100%;
   display: grid;
@@ -24,7 +24,7 @@ export const List = styled<{}, 'div'>('div')`
   }
 `
 
-export const TileActionsContainer = styled<{}, 'nav'>('nav')`
+export const TileActionsContainer = styled.nav`
   box-sizing: border-box;
   opacity: 0;
   visibility: hidden;
@@ -46,7 +46,7 @@ interface TileActionProps {
   standalone?: boolean
 }
 
-export const TileAction = styled<TileActionProps, 'a'>('a')`
+export const TileAction = styled.a<TileActionProps>`
   box-sizing: border-box;
   transition: color 0.1s linear;
   color: #424242;
@@ -73,7 +73,7 @@ interface TileProps {
   isDragging?: boolean
 }
 
-export const Tile = styled<TileProps, 'div'>('div')`
+export const Tile = styled.div<TileProps>`
   background-color: ${p => p.isDragging ? 'rgba(255, 255, 255, 0.5)' : 'rgba(255, 255, 255, 0.8)'};
   position: relative;
   user-select: none;
@@ -95,7 +95,7 @@ export const Tile = styled<TileProps, 'div'>('div')`
   }
 `
 
-export const TileFavicon = styled<{}, 'img'>('img')`
+export const TileFavicon = styled.img`
   display: block;
   height: 72px;
   padding: 16px;

--- a/src/features/newTab/private/box/index.ts
+++ b/src/features/newTab/private/box/index.ts
@@ -8,7 +8,7 @@ import Heading from '../../../../components/text/heading'
 import Button, { Props as ButtonProps } from '../../../../components/buttonsIndicators/button'
 import { DuckDuckGoIcon, TorLockIcon } from '../../../../components/icons'
 
-export const Box = styled<{}, 'section'>('section')`
+export const Box = styled.section`
   box-sizing: border-box;
   -webkit-font-smoothing: antialiased;
   padding: 30px 30px 50px;
@@ -16,12 +16,12 @@ export const Box = styled<{}, 'section'>('section')`
   border: 1px solid rgba(255,255,255,0.25);
 `
 
-export const HeaderBox = styled<{}, 'section'>('section')`
+export const HeaderBox = styled.section`
   box-sizing: border-box;
   -webkit-font-smoothing: antialiased;
 `
 
-export const Content = styled<{}, 'article'>('article')`
+export const Content = styled.article`
   box-sizing: border-box;
   display: block;
   min-height: 285px;
@@ -41,7 +41,7 @@ export const TorLockImage = styled(TorLockIcon)`
   margin-bottom: 20px;
 `
 
-export const PrivateImage = styled<{}, 'img'>('img')`
+export const PrivateImage = styled.img`
   box-sizing: border-box;
   display: block;
   width: 293px;
@@ -51,7 +51,7 @@ export const PrivateImage = styled<{}, 'img'>('img')`
   }
 `
 
-export const TorImage = styled<{}, 'img'>('img')`
+export const TorImage = styled.img`
   box-sizing: border-box;
   display: block;
   width: 177px;
@@ -62,7 +62,7 @@ export const TorImage = styled<{}, 'img'>('img')`
   }
 `
 
-export const SubTitle = styled<{}, 'small'>('small')`
+export const SubTitle = styled.small`
   box-sizing: border-box;
   -webkit-font-smoothing: antialiased;
   display: block;
@@ -80,7 +80,7 @@ export const Title = styled(Heading)`
   color: #fff;
   margin: 0 0 0px;
 `
-export const Text = styled<{}, 'p'>('p')`
+export const Text = styled.p`
   font-family: ${p => p.theme.fontFamily.body};
   letter-spacing: 0.19px;
   line-height: 26px;
@@ -89,7 +89,7 @@ export const Text = styled<{}, 'p'>('p')`
   color: #fff;
 `
 
-export const Separator = styled<{}, 'hr'>('hr')`
+export const Separator = styled.hr`
   border: 1px solid rgba(255,255,255,0.10);
   height: 0;
   width: 100%;
@@ -103,7 +103,7 @@ export const PurpleButton = styled(Button as ComponentType<ButtonProps>)`
   padding: 14px 20px;
   margin: 25px 25px 0 0;
 `
-export const Link = styled<{}, 'a'>('a')`
+export const Link = styled.a`
   font-family: ${p => p.theme.fontFamily.heading};
   font-size: 14px;
   color: #814EFF;
@@ -120,7 +120,7 @@ interface FakeButtonProps {
   withToggle?: boolean
 }
 
-export const FakeButton = styled<FakeButtonProps, 'a'>('a')`
+export const FakeButton = styled.a<FakeButtonProps>`
   display: grid;
   height: 100%;
   grid-template-columns: ${p => p.settings ? 'auto 16px' : 'auto auto'};

--- a/src/features/newTab/private/grid/index.ts
+++ b/src/features/newTab/private/grid/index.ts
@@ -4,7 +4,7 @@
 
 import styled from '../../../../theme'
 
-export const Grid = styled<{}, 'section'>('section')`
+export const Grid = styled.section`
   box-sizing: border-box;
   display: grid;
   height: 100%;
@@ -45,7 +45,7 @@ export const Grid = styled<{}, 'section'>('section')`
   }
 `
 
-export const Grid2Columns = styled<{}, 'section'>('section')`
+export const Grid2Columns = styled.section`
   box-sizing: border-box;
   display: grid;
   height: 100%;
@@ -81,7 +81,7 @@ export const Grid2Columns = styled<{}, 'section'>('section')`
   }
 `
 
-export const HeaderGrid = styled<{}, 'section'>('section')`
+export const HeaderGrid = styled.section`
   box-sizing: border-box;
   display: grid;
   height: 100%;
@@ -110,7 +110,7 @@ export const HeaderGrid = styled<{}, 'section'>('section')`
   }
 `
 
-export const ButtonGroup = styled<{}, 'footer'>('footer')`
+export const ButtonGroup = styled.footer`
   display: flex;
   flex: 1;
   justify-content: flex-start;

--- a/src/features/newTab/private/modal/index.ts
+++ b/src/features/newTab/private/modal/index.ts
@@ -11,7 +11,7 @@ export const Modal = styled(DefaultModal as ComponentType<Props>)`
   height: 100%;
 `
 
-export const LimitedBounds = styled<{}, 'article'>('article')`
+export const LimitedBounds = styled.article`
   overflow: auto;
   height: 500px;
   padding: 20px;
@@ -22,14 +22,14 @@ export const HeadingText = styled(Heading)`
   font-weight: 500;
 `
 
-export const Paragraph = styled<{}, 'p'>('p')`
+export const Paragraph = styled.p`
   font-size: 15px;
   font-family: ${p => p.theme.fontFamily.body};
   letter-spacing: .3px;
   line-height: 24px;
 `
 
-export const Footer = styled<{}, 'footer'>('footer')`
+export const Footer = styled.footer`
   display: flex;
   justify-content: flex-end;
 `

--- a/src/features/newTab/private/page/index.ts
+++ b/src/features/newTab/private/page/index.ts
@@ -8,7 +8,7 @@ interface PageProps {
   isPrivate: boolean
 }
 
-export const Page = styled<PageProps, 'div'>('div')`
+export const Page = styled.div<PageProps>`
   box-sizing: border-box;
   -webkit-font-smoothing: antialiased;
   background: linear-gradient(${p => p.isPrivate ? '#381980' : '#5F0C8A'}, #0C041E);
@@ -16,7 +16,7 @@ export const Page = styled<PageProps, 'div'>('div')`
   height: initial;
 `
 
-export const PageWrapper = styled<{}, 'main'>('main')`
+export const PageWrapper = styled.main`
   box-sizing: border-box;
   padding: 85px 15px;
   max-width: 950px;

--- a/src/features/rewards/alert/style.ts
+++ b/src/features/rewards/alert/style.ts
@@ -51,7 +51,7 @@ const getColor = (p: Props) => {
   `
 }
 
-export const StyledWrapper = styled<Props, 'div'>('div')`
+export const StyledWrapper = styled.div<Props>`
   height: 100%;
   display: flex;
   justify-content: flex-start;
@@ -65,13 +65,13 @@ export const StyledWrapper = styled<Props, 'div'>('div')`
   background: var(--alert-wrapper-color);
 `
 
-export const StyledIcon = styled<{}, 'span'>('span')`
+export const StyledIcon = styled.span`
   width: 40px;
   height: 40px;
   flex-basis: 40px;
 `
 
-export const StyledContent = styled<Props, 'div'>('div')`
+export const StyledContent = styled.div<Props>`
   flex-grow: 1;
   flex-basis: 50%;
   padding-left: 19px;
@@ -88,7 +88,7 @@ export const StyledContent = styled<Props, 'div'>('div')`
   }
 `
 
-export const StyledClose = styled<{}, 'div'>('div')`
+export const StyledClose = styled.div`
   width: 11px;
   height: 11px;
   position: absolute;
@@ -97,14 +97,14 @@ export const StyledClose = styled<{}, 'div'>('div')`
   z-index: 2;
 `
 
-export const StyledError = styled<{}, 'div'>('div')`
+export const StyledError = styled.div`
   color: #F43405;
 `
 
-export const StyledSuccess = styled<{}, 'div'>('div')`
+export const StyledSuccess = styled.div`
   color: #1BBA6A;
 `
 
-export const StyledWarning = styled<{}, 'div'>('div')`
+export const StyledWarning = styled.div`
   color: #FF7900;
 `

--- a/src/features/rewards/amount/style.ts
+++ b/src/features/rewards/amount/style.ts
@@ -5,7 +5,7 @@
 import styled from 'styled-components'
 import { Props } from './index'
 
-export const StyledWrapper = styled<Partial<Props>, 'button'>('button')`
+export const StyledWrapper = styled.button<Partial<Props>>`
   user-select: none;
   font-family: Poppins, sans-serif;
   border: none;
@@ -17,7 +17,7 @@ export const StyledWrapper = styled<Partial<Props>, 'button'>('button')`
   margin: ${p => p.isMobile ? '0 auto 8px auto' : '0 0 8px 0'};
 `
 
-export const StyledAmount = styled<Partial<Props>, 'div'>('div')`
+export const StyledAmount = styled.div<Partial<Props>>`
   opacity: 1;
   border-radius: 20px;
   color: #fff;
@@ -36,7 +36,7 @@ export const StyledAmount = styled<Partial<Props>, 'div'>('div')`
   margin-bottom: ${p => p.isMobile ? 5 : 0}px;
 `
 
-export const StyledTokens = styled<{}, 'div'>('div')`
+export const StyledTokens = styled.div`
   font-weight: 400;
   margin-left: 5px;
 `
@@ -45,12 +45,12 @@ export const StyledNumber = styled.span`
   font-weight: 400;
 `
 
-export const StyledLogo = styled<Partial<Props>, 'div'>('div')`
+export const StyledLogo = styled.div<Partial<Props>>`
   margin-right: 6px;
   width: ${p => p.isMobile ? 20 : 23}px;
 `
 
-export const StyledConverted = styled<Partial<Props>, 'div'>('div')`
+export const StyledConverted = styled.div<Partial<Props>>`
   vertical-align: baseline;
   opacity: ${p => p.selected ? 1 : 0.4};
   font-size: ${p => p.type === 'big' ? '12px' : '10px'};

--- a/src/features/rewards/box/style.ts
+++ b/src/features/rewards/box/style.ts
@@ -25,7 +25,7 @@ const colors: Record<Type, string> = {
   donation: '#696FDC'
 }
 
-export const StyledWrapper = styled<StyleProps, 'div'>('div')`
+export const StyledWrapper = styled.div<StyleProps>`
   display: block;
   width: 100%;
   margin-bottom: 28px;
@@ -37,29 +37,29 @@ export const StyledCard = styled(Card as ComponentType<CardStyleProps>)`
   border-bottom-right-radius: ${p => p.hasAlert ? 0 : 6}px;
 `
 
-export const StyledFlip = styled<StyleProps, 'div'>('div')`
+export const StyledFlip = styled.div<StyleProps>`
   display: block;
 `
 
-export const StyledContentWrapper = styled<StyleProps, 'div'>('div')`
+export const StyledContentWrapper = styled.div<StyleProps>`
   flex-wrap: wrap;
   display: ${p => p.open ? 'flex' : 'none'};
 `
 
-export const StyledLeft = styled<{}, 'div'>('div')`
+export const StyledLeft = styled.div`
   flex-grow: 1;
   flex-shrink: 1;
   flex-basis: 50%;
 `
 
-export const StyledRight = styled<StyleProps, 'div'>('div')`
+export const StyledRight = styled.div<StyleProps>`
   flex-basis: 40px;
   justify-content: flex-end;
   display: flex;
   max-height: 30px;
 `
 
-export const StyledTitle = styled<StyleProps, 'div'>('div')`
+export const StyledTitle = styled.div<StyleProps>`
   height: 36px;
   font-size: 22px;
   font-weight: 600;
@@ -68,12 +68,12 @@ export const StyledTitle = styled<StyleProps, 'div'>('div')`
   color: ${p => p.type && colors[p.type] || '#4b4c5c'};
 `
 
-export const StyledBreak = styled<{}, 'div'>('div')`
+export const StyledBreak = styled.div`
   width: 100%;
   display: block;
 `
 
-export const StyledDescription = styled<{}, 'div'>('div')`
+export const StyledDescription = styled.div`
   width: 100%;
   padding-right: 20px;
   font-family: Muli, sans-serif;
@@ -83,7 +83,7 @@ export const StyledDescription = styled<{}, 'div'>('div')`
   color: #838391;
 `
 
-export const StyledSettingsIcon = styled<StyleProps, 'button'>('button')`
+export const StyledSettingsIcon = styled.button<StyleProps>`
   width: 27px;
   border: none;
   background: none;
@@ -92,18 +92,18 @@ export const StyledSettingsIcon = styled<StyleProps, 'button'>('button')`
   color: #A1A8F2;
 `
 
-export const StyledContent = styled<{}, 'div'>('div')`
+export const StyledContent = styled.div`
   flex-basis: 100%;
   flex-grow: 1;
   margin-top: 25px;
 `
 
-export const StyledSettingsWrapper = styled<StyleProps, 'div'>('div')`
+export const StyledSettingsWrapper = styled.div<StyleProps>`
   background: #fff;
   display: ${p => p.open ? 'block' : 'none'};
 `
 
-export const StyledSettingsClose = styled<StyleProps, 'button'>('button')`
+export const StyledSettingsClose = styled.button<StyleProps>`
   display: ${p => p.open ? 'block' : 'none'};
   position: absolute;
   right: 29px;
@@ -117,14 +117,14 @@ export const StyledSettingsClose = styled<StyleProps, 'button'>('button')`
   color: ${palette.grey600};
 `
 
-export const StyledSettingsTitle = styled<{}, 'div'>('div')`
+export const StyledSettingsTitle = styled.div`
   margin-bottom: 15px;
   display: flex;
   align-items: center;
   justify-content: center;
 `
 
-export const StyledSettingsText = styled<{}, 'div'>('div')`
+export const StyledSettingsText = styled.div`
   font-size: 16px;
   font-weight: 600;
   line-height: 1.75;

--- a/src/features/rewards/disabledContent/style.ts
+++ b/src/features/rewards/disabledContent/style.ts
@@ -30,7 +30,7 @@ const getColors = (p: Props) => {
   `
 }
 
-export const StyledContent = styled<Props, 'div'>('div')`
+export const StyledContent = styled.div<Props>`
   font-family: Poppins, sans-serif;
   font-size: 16px;
   font-weight: 500;
@@ -56,26 +56,26 @@ export const StyledContent = styled<Props, 'div'>('div')`
   }
 `
 
-export const StyledGrid = styled<{}, 'div'>('div')`
+export const StyledGrid = styled.div`
   display: grid;
   grid-template-columns: repeat(3,1fr);
   grid-gap: 32px;
   box-sizing: border-box;
 `
 
-export const StyledOneColumn = styled<{}, 'div'>('div')`
+export const StyledOneColumn = styled.div`
   display: flex;
   grid-column: span 1;
   justify-content: flex-end;
 `
 
-export const StyledTwoColumn = styled<{}, 'div'>('div')`
+export const StyledTwoColumn = styled.div`
   display: flex;
   justify-content: center;
   flex-direction: column;
   grid-column: span 2;
 `
 
-export const StyledIcon = styled<{}, 'div'>('div')`
+export const StyledIcon = styled.div`
   width: 110px;
 `

--- a/src/features/rewards/disabledPanel/style.ts
+++ b/src/features/rewards/disabledPanel/style.ts
@@ -5,21 +5,21 @@
 
 import styled from 'styled-components'
 
-export const StyledWrapper = styled<{}, 'div'>('div')`
+export const StyledWrapper = styled.div`
   width: 100%;
   padding: 30px 25px 25px;
   font-family: Poppins, sans-serif;
   background-image: linear-gradient(140deg, #392DD1 0%, #8E2995 100%);
 `
 
-export const StyledTitle = styled<{}, 'div'>('div')`
+export const StyledTitle = styled.div`
   font-size: 16px;
   color: #F1F1F9;
   font-weight: 500;
   letter-spacing: 0;
 `
 
-export const StyledOff = styled<{}, 'div'>('div')`
+export const StyledOff = styled.div`
   font-size: 16px;
   color: #FFFFFF;
   font-weight: 600;
@@ -27,7 +27,7 @@ export const StyledOff = styled<{}, 'div'>('div')`
   margin-left: 3px;
 `
 
-export const StyledText = styled<{}, 'div'>('div')`
+export const StyledText = styled.div`
   color: #F1F1F9;
   font-size: 14px;
   font-family: Muli,sans-serif;
@@ -38,13 +38,13 @@ export const StyledText = styled<{}, 'div'>('div')`
   margin-top: 7px;
 `
 
-export const StyledLink = styled<{}, 'a'>('a')`
+export const StyledLink = styled.a`
   cursor: pointer;
   margin-left: 4px;
   display: inline-block;
   color: #8D92E2;
 `
 
-export const StyledTitleWrapper = styled<{}, 'div'>('div')`
+export const StyledTitleWrapper = styled.div`
   display: flex;
 `

--- a/src/features/rewards/donate/style.ts
+++ b/src/features/rewards/donate/style.ts
@@ -64,19 +64,19 @@ const getAmountStyle = (isMobile?: boolean) => {
   `
 }
 
-export const StyledWrapper = styled<StyleProps, 'div'>('div')`
+export const StyledWrapper = styled.div<StyleProps>`
   position: relative;
   font-family: Poppins, sans-serif;
   margin: ${p => p.isMobile ? '0 auto 8px auto' : 0}px
   ${getStyle}
 `
 
-export const StyledContent = styled<StyleProps, 'div'>('div')`
+export const StyledContent = styled.div<StyleProps>`
   margin-top: ${p => p.isMobile ? -30 : 0}px;
   padding: ${p => p.isMobile ? '0px' : 'var(--donate-content-padding)'};
 `
 
-export const StyledDonationTitle = styled<StyleProps, 'div'>('div')`
+export const StyledDonationTitle = styled.div<StyleProps>`
   font-size: 16px;
   font-weight: 600;
   line-height: 1.75;
@@ -89,7 +89,7 @@ export const StyledDonationTitle = styled<StyleProps, 'div'>('div')`
   padding-left: ${p => p.isMobile ? 20 : 0}px;
 `
 
-export const StyledSend = styled<{}, 'div'>('div')`
+export const StyledSend = styled.div`
   background: var(--donate-send-bg);
   font-size: 13px;
   font-weight: 600;
@@ -103,7 +103,7 @@ export const StyledSend = styled<{}, 'div'>('div')`
   cursor: pointer;
 `
 
-export const StyledSendButton = styled<{}, 'button'>('button')`
+export const StyledSendButton = styled.button`
   display: block;
   border: none;
   font-size: 13px;
@@ -113,13 +113,13 @@ export const StyledSendButton = styled<{}, 'button'>('button')`
   cursor: pointer;
 `
 
-export const StyledButtonWrapper = styled<StyleProps, 'div'>('div')`
+export const StyledButtonWrapper = styled.div<StyleProps>`
   display: block;
   width: ${p => p.isMobile ? 190 : 245}px;
   margin: 0 auto;
 `
 
-export const StyledIconSend = styled<StyleProps, 'span'>('span')`
+export const StyledIconSend = styled.span<StyleProps>`
   vertical-align: middle;
   display: inline-block;
   margin-right: 15px;
@@ -128,7 +128,7 @@ export const StyledIconSend = styled<StyleProps, 'span'>('span')`
   height: 27px;
 `
 
-export const StyledFunds = styled<{}, 'div'>('div')`
+export const StyledFunds = styled.div`
   font-family: Muli, sans-serif;
   font-size: 13px;
   font-weight: 300;
@@ -149,17 +149,17 @@ export const StyledFunds = styled<{}, 'div'>('div')`
   }
 `
 
-export const StyledIconFace = styled<{}, 'div'>('div')`
+export const StyledIconFace = styled.div`
   flex-basis: 32px;
   margin: -7px 6px 0 0;
 `
 
-export const StyledFundsText = styled<{}, 'div'>('div')`
+export const StyledFundsText = styled.div`
   flex: 1;
   margin-right: 9px;
 `
 
-export const StyledAmountsWrapper = styled<StyleProps, 'div'>('div')`
+export const StyledAmountsWrapper = styled.div<StyleProps>`
   width: 100%;
   display: block;
   ${p => getAmountStyle(p.isMobile)}

--- a/src/features/rewards/donationOverlay/style.ts
+++ b/src/features/rewards/donationOverlay/style.ts
@@ -14,11 +14,11 @@ interface StyleProps {
   logoBgColor?: CSS.Color
 }
 
-export const StyledOuterWrapper = styled<{}, 'div'>('div')`
+export const StyledOuterWrapper = styled.div`
   display: flex;
 `
 
-export const StyledWrapper = styled<{}, 'div'>('div')`
+export const StyledWrapper = styled.div`
   display: flex;
   position: fixed;
   top: 0;
@@ -30,7 +30,7 @@ export const StyledWrapper = styled<{}, 'div'>('div')`
   justify-content: center;
 `
 
-export const StyledHeaderText = styled<{}, 'span'>('span')`
+export const StyledHeaderText = styled.span`
   color: #D1D1DB;
   font-size: 38px;
   font-weight: 600;
@@ -38,36 +38,36 @@ export const StyledHeaderText = styled<{}, 'span'>('span')`
   line-height: 28px;
 `
 
-export const StyledOverlayTop = styled<{}, 'div'>('div')`
+export const StyledOverlayTop = styled.div`
   display: flex;
   flex-direction: row;
   padding-top: 110px;
 `
 
-export const StyledOverlayContent = styled<{}, 'div'>('div')`
+export const StyledOverlayContent = styled.div`
   display: block;
 `
 
-export const StyledIconWrapper = styled<StyleProps, 'span'>('span')`
+export const StyledIconWrapper = styled.span<StyleProps>`
   flex: 1 0 0;
   margin-top: ${p => p.success ? 0 : '-25px'}
 `
 
-export const StyledIcon = styled<{}, 'span'>('span')`
+export const StyledIcon = styled.span`
   width: 90px;
   margin-top: -7px;
   margin-right: 9px;
   display: inline-block;
 `
 
-export const StyledMessage = styled<StyleProps, 'div'>('div')`
+export const StyledMessage = styled.div<StyleProps>`
   flex: 9 0 0;
   padding-top: 10px;
   text-align: ${p => p.monthly ? 'center' : 'inherit'};
   margin-right: ${p => p.success ? 0 : '-10px'}
 `
 
-export const StyledProviderImage = styled<StyleProps, 'div'>('div')`
+export const StyledProviderImage = styled.div<StyleProps>`
   width: 90px;
   height: 90px;
   padding: 0 20px;
@@ -78,7 +78,7 @@ export const StyledProviderImage = styled<StyleProps, 'div'>('div')`
   background-image:url(${p => p.src ? p.src : ''});
 `
 
-export const StyledImageBorder = styled<{}, 'div'>('div')`
+export const StyledImageBorder = styled.div`
   position: relative;
   top: 0;
   left: -20px;
@@ -88,7 +88,7 @@ export const StyledImageBorder = styled<{}, 'div'>('div')`
   border: 5px solid #ffffff;
 `
 
-export const StyledFailWrapper = styled<{}, 'div'>('div')`
+export const StyledFailWrapper = styled.div`
   margin-top: 110px;
   padding-left: 5px;
   display: flex;
@@ -96,11 +96,11 @@ export const StyledFailWrapper = styled<{}, 'div'>('div')`
   align-items: center;
 `
 
-export const StyledCloseIcon = styled<{}, 'span'>('span')`
+export const StyledCloseIcon = styled.span`
   color: #FFF;
 `
 
-export const StyledClose = styled<{}, 'button'>('button')`
+export const StyledClose = styled.button`
   top: 20px;
   right: 20px;
   position: absolute;
@@ -114,7 +114,7 @@ export const StyledClose = styled<{}, 'button'>('button')`
   z-index: 2;
 `
 
-export const StyledFailTitle = styled<{}, 'span'>('span')`
+export const StyledFailTitle = styled.span`
   color: #FFFFFF;
   font-size: 28px;
   font-weight: 600;
@@ -124,7 +124,7 @@ export const StyledFailTitle = styled<{}, 'span'>('span')`
   margin-bottom: 10px;
 `
 
-export const StyledFailMsg = styled<{}, 'span'>('span')`
+export const StyledFailMsg = styled.span`
   color: #FFFFFF;
   font-size: 16px;
   font-family: "Muli", sans-serif;
@@ -136,7 +136,7 @@ export const StyledFailMsg = styled<{}, 'span'>('span')`
   width: 249px;
 `
 
-export const StyledBackgroundCurve = styled<{}, 'div'>('div')`
+export const StyledBackgroundCurve = styled.div`
   position: fixed;
   top: 0;
   left: -19px;
@@ -147,7 +147,7 @@ export const StyledBackgroundCurve = styled<{}, 'div'>('div')`
   border-bottom-right-radius: 140%;
 `
 
-export const StyleSubHeaderText = styled<{}, 'div'>('div')`
+export const StyleSubHeaderText = styled.div`
   font-size: 16px;
   font-family: "Muli", sans-serif;
   font-weight: normal;
@@ -156,7 +156,7 @@ export const StyleSubHeaderText = styled<{}, 'div'>('div')`
   display: block;
   margin: 10px 0 0 5px;
 `
-export const StyledLetter = styled<StyleProps, 'div'>('div')`
+export const StyledLetter = styled.div<StyleProps>`
   border: 6px solid #fff;
   border-radius: 50%;
   width: 102px;
@@ -171,19 +171,19 @@ export const StyledLetter = styled<StyleProps, 'div'>('div')`
   text-transform: uppercase;
 `
 
-export const StyledLogoImage = styled<StyleProps, 'div'>('div')`
+export const StyledLogoImage = styled.div<StyleProps>`
   width: 90px;
   height: 90px;
   background: url(${p => p.bg}) no-repeat;
   background-size: cover;
 `
 
-export const StyledLogoWrapper = styled<{}, 'div'>('div')`
+export const StyledLogoWrapper = styled.div`
   padding-right: 25px;
   flex-basis: 217px;
 `
 
-export const StyledLogoBorder = styled<StyleProps, 'div'>('div')`
+export const StyledLogoBorder = styled.div<StyleProps>`
   border: 6px solid #fff;
   border-radius: 50%;
   width: 102px;
@@ -193,11 +193,11 @@ export const StyledLogoBorder = styled<StyleProps, 'div'>('div')`
   overflow: hidden;
 `
 
-export const StyledMonthlyInfo = styled<{}, 'div'>('div')`
+export const StyledMonthlyInfo = styled.div`
   color: #fff;
 `
 
-export const StyledDomainText = styled<{}, 'span'>('span')`
+export const StyledDomainText = styled.span`
   display: block;
   font-size: 22px;
   margin: 10px 0 25px;
@@ -206,7 +206,7 @@ export const StyledDomainText = styled<{}, 'span'>('span')`
   line-height: 32px;
 `
 
-export const StyledDateText = styled<{}, 'span'>('span')`
+export const StyledDateText = styled.span`
   display: block;
   font-size: 16px;
   font-weight: normal;
@@ -215,7 +215,7 @@ export const StyledDateText = styled<{}, 'span'>('span')`
   line-height: 28px;
 `
 
-export const StyledDate = styled<{}, 'span'>('span')`
+export const StyledDate = styled.span`
   display: block;
   font-size: 16px;
   font-weight: 500;

--- a/src/features/rewards/grantCaptcha/index.tsx
+++ b/src/features/rewards/grantCaptcha/index.tsx
@@ -97,9 +97,9 @@ export default class GrantCaptcha extends React.PureComponent<Props, {}> {
     return (
       <StyledWrapper
         id={id}
-        innerRef={this.refWrapper}
+        ref={this.refWrapper}
       >
-        <StyledDrag innerRef={this.refDrag}>
+        <StyledDrag ref={this.refDrag}>
           <StyledImageWrap>
             <StyledImage src={batUrl} onDragStart={this.onCaptchaDrag} draggable={true} />
           </StyledImageWrap>

--- a/src/features/rewards/grantCaptcha/style.ts
+++ b/src/features/rewards/grantCaptcha/style.ts
@@ -4,30 +4,30 @@
 
 import styled from 'styled-components'
 
-export const StyledWrapper = styled<{}, 'div'>('div')`
+export const StyledWrapper = styled.div`
   text-align: center;
   margin: 15px 0 0 -32px;
   width: 333px;
 `
 
-export const StyledDropArea = styled<{}, 'img'>('img')`
+export const StyledDropArea = styled.img`
   width: 333px;
   height: 296px;
 `
 
-export const StyledDrag = styled<{}, 'div'>('div')`
+export const StyledDrag = styled.div`
   display: flex;
   justify-content: center;
 `
 
-export const StyledImageWrap = styled<{}, 'div'>('div')`
+export const StyledImageWrap = styled.div`
   flex-basis: 80px;
   flex-shrink: 0;
   display: flex;
   justify-content: center;
 `
 
-export const StyledText = styled<{}, 'div'>('div')`
+export const StyledText = styled.div`
   flex-basis: 130px;
   font-family: Muli, sans-serif;
   font-size: 14px;
@@ -37,7 +37,7 @@ export const StyledText = styled<{}, 'div'>('div')`
   padding-left: 13px;
 `
 
-export const StyledImage = styled<{}, 'img'>('img')`
+export const StyledImage = styled.img`
   width: 60px;
   height: 52px;
 `

--- a/src/features/rewards/grantClaim/style.ts
+++ b/src/features/rewards/grantClaim/style.ts
@@ -10,7 +10,7 @@ interface StyleProps {
   isMobile?: boolean
 }
 
-export const StyledWrapper = styled<StyleProps, 'div'>('div')`
+export const StyledWrapper = styled.div<StyleProps>`
   display: flex;
   align-items: center;
   flex-wrap: nowrap;
@@ -24,7 +24,7 @@ export const StyledWrapper = styled<StyleProps, 'div'>('div')`
   box-shadow: 0 1px 12px 0 rgba(99,105,110,0.18);
 `
 
-export const StyledIcon = styled<StyleProps, 'div'>('div')`
+export const StyledIcon = styled.div<StyleProps>`
   flex-basis: 42px;
   height: 42px;
   width: 52px;
@@ -32,7 +32,7 @@ export const StyledIcon = styled<StyleProps, 'div'>('div')`
   color: ${p => p.type === 'ads' ? '#C12D7C' : '#FF9868'};
 `
 
-export const StyledText = styled<{}, 'div'>('div')`
+export const StyledText = styled.div`
   flex-grow: 1;
   flex-shrink: 1;
   flex-basis: 70%;
@@ -43,7 +43,7 @@ export const StyledText = styled<{}, 'div'>('div')`
   padding: 0 10px;
 `
 
-export const StyledClaim = styled<{}, 'button'>('button')`
+export const StyledClaim = styled.button`
   flex-basis: 90px;
   height: 64px;
   background-color: #fb542b;
@@ -61,7 +61,7 @@ export const StyledClaim = styled<{}, 'button'>('button')`
   }
 `
 
-export const StyledLoader = styled<{}, 'span'>('span')`
+export const StyledLoader = styled.span`
   width: 35px;
   height: 35px;
   margin-top: 7px;

--- a/src/features/rewards/grantComplete/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/grantComplete/__snapshots__/spec.tsx.snap
@@ -41,10 +41,10 @@ exports[`Grant complete tests basic tests matches the snapshot 1`] = `
   margin-top: 0px;
 }
 
-.c7 {
-  --button-main-color: #ff7654;
-  --button-main-color-hover: #FB542B;
-  --button-main-color-active: #ffb8a6;
+.c6 {
+  --button-main-color: #FB542B;
+  --button-main-color-hover: #F43405;
+  --button-main-color-active: #FDBBAA;
   --button-state-color: var(--button-main-color);
   --icon-size: 18px;
   --icon-spacing: 6px;
@@ -79,23 +79,20 @@ exports[`Grant complete tests basic tests matches the snapshot 1`] = `
   width: 100%;
   min-width: 235px;
   padding: 19px 15px;
-}
-
-.c7:hover:enabled {
-  --button-state-color: var(--button-main-color-hover);
-}
-
-.c7:active:enabled {
-  --button-state-color: var(--button-main-color-active);
-}
-
-.c6 {
   color: #fff;
   background: var(--button-state-color);
   border: 1px solid var(--button-state-color);
 }
 
-.c8 {
+.c6:hover:enabled {
+  --button-state-color: var(--button-main-color-hover);
+}
+
+.c6:active:enabled {
+  --button-state-color: var(--button-main-color-active);
+}
+
+.c7 {
   min-height: var(--icon-size);
   display: -webkit-box;
   display: -webkit-flex;
@@ -150,12 +147,12 @@ exports[`Grant complete tests basic tests matches the snapshot 1`] = `
     className="c5"
   >
     <button
-      className="c6 c7"
+      className="c6"
       size="call-to-action"
       type="accent"
     >
       <div
-        className="c8"
+        className="c7"
         size="call-to-action"
         type="accent"
       >

--- a/src/features/rewards/grantComplete/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/grantComplete/__snapshots__/spec.tsx.snap
@@ -42,9 +42,9 @@ exports[`Grant complete tests basic tests matches the snapshot 1`] = `
 }
 
 .c6 {
-  --button-main-color: #FB542B;
-  --button-main-color-hover: #F43405;
-  --button-main-color-active: #FDBBAA;
+  --button-main-color: #ff7654;
+  --button-main-color-hover: #FB542B;
+  --button-main-color-active: #ffb8a6;
   --button-state-color: var(--button-main-color);
   --icon-size: 18px;
   --icon-spacing: 6px;

--- a/src/features/rewards/grantComplete/style.ts
+++ b/src/features/rewards/grantComplete/style.ts
@@ -8,20 +8,20 @@ interface StyleProps {
   isMobile?: boolean
 }
 
-export const StyledWrapper = styled<{}, 'div'>('div')`
+export const StyledWrapper = styled.div`
   text-align: center;
   width: 100%;
   margin: 40px 0 0;
   font-family: Poppins, sans-serif;
 `
 
-export const StyledBox = styled<{}, 'div'>('div')`
+export const StyledBox = styled.div`
   border-radius: 6px;
   background-color: #f1f1f5;
   padding: 5px 10px 20px;
 `
 
-export const StyledTitle = styled<{}, 'div'>('div')`
+export const StyledTitle = styled.div`
   font-size: 14px;
   font-weight: 300;
   line-height: 1.57;
@@ -29,14 +29,14 @@ export const StyledTitle = styled<{}, 'div'>('div')`
   margin: 11px 0 5px;
 `
 
-export const StyledValue = styled<{}, 'div'>('div')`
+export const StyledValue = styled.div`
   font-size: 18px;
   line-height: 1.22;
   text-align: center;
   color: #c12d7c;
 `
 
-export const StyledText = styled<{}, 'div'>('div')`
+export const StyledText = styled.div`
   font-family: Muli, sans-serif;
   font-size: 14px;
   line-height: 1.29;
@@ -44,6 +44,6 @@ export const StyledText = styled<{}, 'div'>('div')`
   margin: 44px 0 32px;
 `
 
-export const StyledButtonWrapper = styled<StyleProps, 'div'>('div')`
+export const StyledButtonWrapper = styled.div<StyleProps>`
   margin-top: ${p => p.isMobile ? 40 : 0}px;
 `

--- a/src/features/rewards/grantError/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/grantError/__snapshots__/spec.tsx.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Grant error tests basic tests matches the snapshot 1`] = `
-.c4 {
-  --button-main-color: #ff7654;
-  --button-main-color-hover: #FB542B;
-  --button-main-color-active: #ffb8a6;
+.c3 {
+  --button-main-color: #FB542B;
+  --button-main-color-hover: #F43405;
+  --button-main-color-active: #FDBBAA;
   --button-state-color: var(--button-main-color);
   --icon-size: 18px;
   --icon-spacing: 6px;
@@ -39,20 +39,17 @@ exports[`Grant error tests basic tests matches the snapshot 1`] = `
   width: 100%;
   min-width: 235px;
   padding: 19px 15px;
-}
-
-.c4:hover:enabled {
-  --button-state-color: var(--button-main-color-hover);
-}
-
-.c4:active:enabled {
-  --button-state-color: var(--button-main-color-active);
-}
-
-.c3 {
   color: #fff;
   background: var(--button-state-color);
   border: 1px solid var(--button-state-color);
+}
+
+.c3:hover:enabled {
+  --button-state-color: var(--button-main-color-hover);
+}
+
+.c3:active:enabled {
+  --button-state-color: var(--button-main-color-active);
 }
 
 .c0 {
@@ -87,7 +84,7 @@ exports[`Grant error tests basic tests matches the snapshot 1`] = `
     className="c2"
   >
     <button
-      className="c3 c4"
+      className="c3"
       size="call-to-action"
       type="accent"
     />

--- a/src/features/rewards/grantError/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/grantError/__snapshots__/spec.tsx.snap
@@ -2,9 +2,9 @@
 
 exports[`Grant error tests basic tests matches the snapshot 1`] = `
 .c3 {
-  --button-main-color: #FB542B;
-  --button-main-color-hover: #F43405;
-  --button-main-color-active: #FDBBAA;
+  --button-main-color: #ff7654;
+  --button-main-color-hover: #FB542B;
+  --button-main-color-active: #ffb8a6;
   --button-state-color: var(--button-main-color);
   --icon-size: 18px;
   --icon-spacing: 6px;

--- a/src/features/rewards/grantError/style.ts
+++ b/src/features/rewards/grantError/style.ts
@@ -4,7 +4,7 @@
 
 import styled from 'styled-components'
 
-export const StyledWrapper = styled<{}, 'div'>('div')`
+export const StyledWrapper = styled.div`
   text-align: center;
   width: 100%;
   padding: 20px 10px;
@@ -12,7 +12,7 @@ export const StyledWrapper = styled<{}, 'div'>('div')`
   min-height: 350px;
 `
 
-export const StyledText = styled<{}, 'div'>('div')`
+export const StyledText = styled.div`
   font-family: Muli, sans-serif;
   font-size: 14px;
   line-height: 1.29;
@@ -20,7 +20,7 @@ export const StyledText = styled<{}, 'div'>('div')`
   margin: 44px 0 32px;
 `
 
-export const StyledButton = styled<{}, 'div'>('div')`
+export const StyledButton = styled.div`
   display: block;
   margin: 0 auto;
 `

--- a/src/features/rewards/grantWrapper/style.ts
+++ b/src/features/rewards/grantWrapper/style.ts
@@ -21,7 +21,7 @@ const getBackground = (props: StyleProps) => {
   return 'rgba(255, 255, 255, 0.95)'
 }
 
-export const StyledWrapper = styled<StyleProps, 'div'>('div')`
+export const StyledWrapper = styled.div<StyleProps>`
   position: ${p => p.fullScreen ? 'fixed' : 'absolute'};
   top: 0;
   left: 0;
@@ -40,13 +40,13 @@ export const StyledWrapper = styled<StyleProps, 'div'>('div')`
   background: ${p => getBackground(p)};
 `
 
-export const StyledHeader = styled<{}, 'div'>('div')`
+export const StyledHeader = styled.div`
   text-align: center;
   width: 100%;
   margin: 59px 0;
 `
 
-export const StyledTitle = styled<StyleProps, 'div'>('div')`
+export const StyledTitle = styled.div<StyleProps>`
   width: 100%;
   font-size: ${p => p.isPanel ? 20 : 28}px;
   font-weight: ${p => p.isPanel ? 'normal' : 500};
@@ -56,7 +56,7 @@ export const StyledTitle = styled<StyleProps, 'div'>('div')`
   color: #fb542b;
 `
 
-export const StyledClose = styled<{}, 'button'>('button')`
+export const StyledClose = styled.button`
   top: 16px;
   right: 16px;
   position: absolute;
@@ -69,7 +69,7 @@ export const StyledClose = styled<{}, 'button'>('button')`
   height: 20px;
 `
 
-export const StyledText = styled<{}, 'div'>('div')`
+export const StyledText = styled.div`
   width: 100%;
   font-family: Muli, sans-serif;
   font-size: 16px;
@@ -79,13 +79,13 @@ export const StyledText = styled<{}, 'div'>('div')`
   color: #4b4c5c;
 `
 
-export const StyledGrantIcon = styled<{}, 'img'>('img')`
+export const StyledGrantIcon = styled.img`
   height: 53px;
   width: 53px;
   margin: 25px auto 15px;
 `
 
-export const StyledPanelText = styled<{}, 'div'>('div')`
+export const StyledPanelText = styled.div`
   padding: 7px;
   font-size: 12px;
   margin: 7px auto 0px;
@@ -93,6 +93,6 @@ export const StyledPanelText = styled<{}, 'div'>('div')`
   border-radius: 8px 8px 8px 8px;
 `
 
-export const StyledHint = styled<{}, 'span'>('span')`
+export const StyledHint = styled.span`
   font-weight: 600;
 `

--- a/src/features/rewards/hero/style.ts
+++ b/src/features/rewards/hero/style.ts
@@ -4,7 +4,7 @@ interface StyleProps {
   isMobile?: boolean
 }
 
-export const StyledHero = styled<StyleProps, 'div'>('div')`
+export const StyledHero = styled.div<StyleProps>`
   text-align: center;
   min-height: 610px;
   padding: 60px 0 25px 0;

--- a/src/features/rewards/infoCard/style.ts
+++ b/src/features/rewards/infoCard/style.ts
@@ -4,7 +4,7 @@
 
 import styled from 'styled-components'
 
-export const StyledInfoCard = styled<{}, 'div'>('div')`
+export const StyledInfoCard = styled.div`
   height: 290px;
   border-radius: 4px;
   text-align: center;
@@ -16,7 +16,7 @@ export const StyledInfoCard = styled<{}, 'div'>('div')`
   font-family: Poppins, sans-serif;
 `
 
-export const StyledTitle = styled<{}, 'strong'>('strong')`
+export const StyledTitle = styled.strong`
   color: #222326;
   font-size: 18px;
   font-weight: 500;
@@ -24,7 +24,7 @@ export const StyledTitle = styled<{}, 'strong'>('strong')`
   letter-spacing: 0.16px;
 `
 
-export const StyledDesc = styled<{}, 'p'>('p')`
+export const StyledDesc = styled.p`
   color: #686978;
   font-size: 16px;
   line-height: 22px;
@@ -34,14 +34,14 @@ export const StyledDesc = styled<{}, 'p'>('p')`
   font-weight: 400;
 `
 
-export const StyledFigure = styled<{}, 'figure'>('figure')`
+export const StyledFigure = styled.figure`
   box-sizing: border-box;
   display: block;
   max-width: 100%;
   margin: 10px auto 20px;
   height: 80px;
 `
-export const StyledGrid = styled<{}, 'div'>('div')`
+export const StyledGrid = styled.div`
   display: grid;
   grid-gap: 0px;
   grid-template-columns: 1fr 1fr 1fr;
@@ -54,6 +54,6 @@ export const StyledGrid = styled<{}, 'div'>('div')`
   }
 `
 
-export const StyledColumn = styled<{}, 'div'>('div')`
+export const StyledColumn = styled.div`
   padding: 0 10px;
 `

--- a/src/features/rewards/list/style.ts
+++ b/src/features/rewards/list/style.ts
@@ -4,7 +4,7 @@
 
 import styled from 'styled-components'
 
-export const StyledWrapper = styled<{}, 'div'>('div')`
+export const StyledWrapper = styled.div`
   position: relative;
   display: flex;
   border-bottom: solid 1px #E5E5EA;
@@ -16,7 +16,7 @@ export const StyledWrapper = styled<{}, 'div'>('div')`
   font-family: Poppins, sans-serif;
 `
 
-export const StyledTitle = styled<{}, 'div'>('div')`
+export const StyledTitle = styled.div`
   font-size: 16px;
   line-height: 1;
   color: #4b4c5c;
@@ -26,7 +26,7 @@ export const StyledTitle = styled<{}, 'div'>('div')`
   padding: 9px 0 15px;
 `
 
-export const StyledContentWrapper = styled<{}, 'div'>('div')`
+export const StyledContentWrapper = styled.div`
   flex-grow: 1;
   flex-shrink: 1;
   flex-basis: 50%;

--- a/src/features/rewards/listToken/style.ts
+++ b/src/features/rewards/listToken/style.ts
@@ -5,7 +5,7 @@
 import styled from 'styled-components'
 import { Props } from './index'
 
-export const StyledWrapper = styled<Partial<Props>, 'div'>('div')`
+export const StyledWrapper = styled.div<Partial<Props>>`
   position: relative;
   display: flex;
   border-bottom: ${p => p.border === 'last' ? 'none' : '1px solid #d0d6dc'};
@@ -17,7 +17,7 @@ export const StyledWrapper = styled<Partial<Props>, 'div'>('div')`
   font-family: Poppins, sans-serif;
 `
 
-export const StyledTitle = styled<{}, 'div'>('div')`
+export const StyledTitle = styled.div`
   font-size: 14px;
   line-height: 2.79;
   color: #4b4c5c;
@@ -26,7 +26,7 @@ export const StyledTitle = styled<{}, 'div'>('div')`
   flex-basis: 60%;
 `
 
-export const StyledContentWrapper = styled<{}, 'div'>('div')`
+export const StyledContentWrapper = styled.div`
   flex-grow: 1;
   flex-shrink: 1;
   flex-basis: 40%;

--- a/src/features/rewards/mainToggle/style.ts
+++ b/src/features/rewards/mainToggle/style.ts
@@ -4,7 +4,7 @@
 
 import styled from 'styled-components'
 
-export const MainToggleWrapper = styled<{}, 'div'>('div')`
+export const MainToggleWrapper = styled.div`
   font-family: Poppins, sans-serif;
   position: relative;
   display: flex;
@@ -20,13 +20,13 @@ export const MainToggleWrapper = styled<{}, 'div'>('div')`
   margin-bottom: 25px;
 `
 
-export const ToggleHeading = styled<{}, 'div'>('div')`
+export const ToggleHeading = styled.div`
   display: flex;
   align-items: center;
   width: 100%;
 `
 
-export const StyledTitle = styled<{}, 'div'>('div')`
+export const StyledTitle = styled.div`
   margin: 0 0 0 11px;
   flex: 1;
   font-size: 28px;
@@ -38,7 +38,7 @@ export const StyledTitle = styled<{}, 'div'>('div')`
   align-items: center;
 `
 
-export const StyledTM = styled<{}, 'span'>('span')`
+export const StyledTM = styled.span`
   align-self: flex-start;
   font-size: 10px;
   font-weight: 300;
@@ -47,14 +47,14 @@ export const StyledTM = styled<{}, 'span'>('span')`
   color: #222326;
 `
 
-export const StyleTitle = styled<{}, 'div'>('div')`
+export const StyleTitle = styled.div`
   margin-top: 18px;
   font-size: 22px;
   line-height: 1.27;
   color: #4b4c5c;
 `
 
-export const StyleText = styled<{}, 'div'>('div')`
+export const StyleText = styled.div`
   font-family: Muli, sans-serif;
   font-size: 16px;
   font-weight: 300;
@@ -62,11 +62,11 @@ export const StyleText = styled<{}, 'div'>('div')`
   color: #838391;
 `
 
-export const StyledContent = styled<{}, 'div'>('div')`
+export const StyledContent = styled.div`
   flex-basis: 100%;
 `
 
-export const StyledLogoWrapper = styled<{}, 'div'>('div')`
+export const StyledLogoWrapper = styled.div`
   width: 66px;
   height: 66px;
 `

--- a/src/features/rewards/mobile/boxMobile/style.ts
+++ b/src/features/rewards/mobile/boxMobile/style.ts
@@ -45,29 +45,29 @@ export const StyledCard = styled(Card as ComponentType<CardStyleProps>)`
   font-family: Poppins, sans-serif;
 `
 
-export const StyledFlip = styled<{}, 'div'>('div')`
+export const StyledFlip = styled.div`
   display: block;
 `
 
-export const StyledContentWrapper = styled<StyleProps, 'div'>('div')`
+export const StyledContentWrapper = styled.div<StyleProps>`
   flex-wrap: wrap;
   display: ${p => p.open ? 'flex' : 'none'};
 `
 
-export const StyledLeft = styled<{}, 'div'>('div')`
+export const StyledLeft = styled.div`
   flex-grow: 1;
   flex-shrink: 1;
   flex-basis: 50%;
 `
 
-export const StyledRight = styled<{}, 'div'>('div')`
+export const StyledRight = styled.div`
   flex-basis: 40px;
   justify-content: flex-end;
   display: flex;
   max-height: 30px;
 `
 
-export const StyledTitle = styled<StyleProps, 'div'>('div')`
+export const StyledTitle = styled.div<StyleProps>`
   height: 36px;
   font-size: 18px;
   font-weight: 600;
@@ -83,12 +83,12 @@ export const StyledTitle = styled<StyleProps, 'div'>('div')`
   margin-top: ${p => p.contentShown ? 3 : -5}px;
 `
 
-export const StyledBreak = styled<{}, 'div'>('div')`
+export const StyledBreak = styled.div`
   width: 100%;
   display: block;
 `
 
-export const StyledDescription = styled<StyleProps, 'div'>('div')`
+export const StyledDescription = styled.div<StyleProps>`
   width: 100%;
   font-family: Muli, sans-serif;
   font-size: 14px;
@@ -99,20 +99,20 @@ export const StyledDescription = styled<StyleProps, 'div'>('div')`
   margin-top: ${p => p.contentShown ? 0 : -5}px;
 `
 
-export const StyledContent = styled<StyleProps, 'div'>('div')`
+export const StyledContent = styled.div<StyleProps>`
   flex-basis: 100%;
   flex-grow: 1;
   margin-top: ${p => p.contentShown ? 15 : 10}px;
   text-align: ${p => p.contentShown ? 'default' : 'center'};
 `
 
-export const StyledSettingsWrapper = styled<StyleProps, 'div'>('div')`
+export const StyledSettingsWrapper = styled.div<StyleProps>`
   background: #fff;
   overflow: hidden;
   display: ${p => p.open ? 'block' : 'none'};
 `
 
-export const StyledSettingsClose = styled<{}, 'button'>('button')`
+export const StyledSettingsClose = styled.button`
   display: block;
   position: absolute;
   right: 15px;
@@ -126,7 +126,7 @@ export const StyledSettingsClose = styled<{}, 'button'>('button')`
   color: #DFDFE8;
 `
 
-export const StyledSettingsTitle = styled<{}, 'span'>('span')`
+export const StyledSettingsTitle = styled.span`
   color: #4B4C5C;
   font-size: 16px;
   font-weight: 600;
@@ -138,7 +138,7 @@ export const StyledSettingsTitle = styled<{}, 'span'>('span')`
   padding-top: 25px;
 `
 
-export const StyledSettingsText = styled<{}, 'div'>('div')`
+export const StyledSettingsText = styled.div`
   display: inline-block;
   vertical-align: top;
   color: #4B4C5C;
@@ -149,7 +149,7 @@ export const StyledSettingsText = styled<{}, 'div'>('div')`
   margin-left: 5px;
 `
 
-export const StyleDetailsLink = styled<{}, 'a'>('a')`
+export const StyleDetailsLink = styled.a`
   color: #4C54D2;
   font-size: 14px;
   font-weight: 500;
@@ -157,34 +157,34 @@ export const StyleDetailsLink = styled<{}, 'a'>('a')`
   line-height: 28px;
 `
 
-export const StyledDetailInfo = styled<{}, 'div'>('div')`
+export const StyledDetailInfo = styled.div`
   width: 100%;
   padding: 0px 21px 20px;
   display: block;
 `
 
-export const StyledDetailContent = styled<{}, 'div'>('div')`
+export const StyledDetailContent = styled.div`
   margin-top: 80px;
 `
 
-export const StyledChildContent = styled<{}, 'div'>('div')`
+export const StyledChildContent = styled.div`
   width: 100%;
   display: block;
   border-top: 1px solid #E5E5EA;
 `
 
-export const StyledSettingsContent = styled<{}, 'div'>('div')`
+export const StyledSettingsContent = styled.div`
   width: 100%;
   padding: 25px;
   display: block;
 `
 
-export const StyledSettingsHeader = styled<{}, 'div'>('div')`
+export const StyledSettingsHeader = styled.div`
   width: 100%;
   display: block;
 `
 
-export const StyledSettingsListTitle = styled<{}, 'span'>('span')`
+export const StyledSettingsListTitle = styled.span`
   vertical-align: top;
   font-weight: 300;
   font-size: 16px;
@@ -194,7 +194,7 @@ export const StyledSettingsListTitle = styled<{}, 'span'>('span')`
   margin: 5px 0px -10px 22px;
 `
 
-export const StyledArrow = styled<{}, 'span'>('span')`
+export const StyledArrow = styled.span`
   color: #4C54D2;
   height: 16px;
   width: 16px;
@@ -203,7 +203,7 @@ export const StyledArrow = styled<{}, 'span'>('span')`
   line-height: 16px;
 `
 
-export const StyledToggleHeader = styled<StyleProps, 'div'>('div')`
+export const StyledToggleHeader = styled.div<StyleProps>`
   width: 100%;
   display: flex;
   ${p => getFixedStyling(p.detailView)}
@@ -212,14 +212,14 @@ export const StyledToggleHeader = styled<StyleProps, 'div'>('div')`
   z-index: 1;
 `
 
-export const StyledBackArrow = styled<{}, 'span'>('span')`
+export const StyledBackArrow = styled.span`
   height: 28px;
   width: 25px;
   display: inline-block;
   margin-right: -3px;
 `
 
-export const StyledFullSizeWrapper = styled<{}, 'div'>('div')`
+export const StyledFullSizeWrapper = styled.div`
   display: block;
   position: fixed;
   top: 0;
@@ -231,7 +231,7 @@ export const StyledFullSizeWrapper = styled<{}, 'div'>('div')`
   overflow-y: scroll;
 `
 
-export const StyledSettingsIcon = styled<{}, 'button'>('button')`
+export const StyledSettingsIcon = styled.button`
   width: 27px;
   border: none;
   background: none;
@@ -240,7 +240,7 @@ export const StyledSettingsIcon = styled<{}, 'button'>('button')`
   color: #A1A8F2;
 `
 
-export const StyledToggleWrapper = styled<StyleProps, 'div'>('div')`
+export const StyledToggleWrapper = styled.div<StyleProps>`
   margin-right: -5px;
   margin-top: ${p => p.contentShown ? 5 : 6}px;
 `

--- a/src/features/rewards/mobile/mainToggleMobile/style.ts
+++ b/src/features/rewards/mobile/mainToggleMobile/style.ts
@@ -4,7 +4,7 @@
 
 import styled from 'styled-components'
 
-export const StyledWrapper = styled<{}, 'div'>('div')`
+export const StyledWrapper = styled.div`
   font-family: Poppins, sans-serif;
   display: flex;
   width: 100%;
@@ -21,7 +21,7 @@ export const StyledWrapper = styled<{}, 'div'>('div')`
   box-shadow: 0 0 2px 0 rgba(99,105,110,0.55);
 `
 
-export const StyledLeft = styled<{}, 'div'>('div')`
+export const StyledLeft = styled.div`
   flex-grow: 1;
   flex-shrink: 1;
   display: flex;
@@ -29,14 +29,14 @@ export const StyledLeft = styled<{}, 'div'>('div')`
   padding: 0px 13px;
 `
 
-export const StyledRight = styled<{}, 'div'>('div')`
+export const StyledRight = styled.div`
   height: 66px;
   position: fixed;
   right: 15px;
   top: 18px;
 `
 
-export const StyledTitle = styled<{}, 'div'>('div')`
+export const StyledTitle = styled.div`
   color: #4B4C5C;
   font-size: 22px;
   font-weight: 500;
@@ -53,7 +53,7 @@ export const StyledTitle = styled<{}, 'div'>('div')`
   }
 `
 
-export const StyledTM = styled<{}, 'span'>('span')`
+export const StyledTM = styled.span`
   font-size: 8px;
   font-weight: 300;
   letter-spacing: 0.2px;
@@ -68,7 +68,7 @@ export const StyledTM = styled<{}, 'span'>('span')`
   }
 `
 
-export const StyledLogoWrapper = styled<{}, 'div'>('div')`
+export const StyledLogoWrapper = styled.div`
   width: 30px;
   height: 30px;
   margin-top: 13px;

--- a/src/features/rewards/mobile/selectMobile/style.ts
+++ b/src/features/rewards/mobile/selectMobile/style.ts
@@ -4,7 +4,7 @@ interface StyleProps {
   floating?: boolean
 }
 
-export const StyledSelect = styled<StyleProps, 'select'>('select')`
+export const StyledSelect = styled.select<StyleProps>`
   width: 100%;
   background: #fff;
   height: 34px;

--- a/src/features/rewards/mobile/settingsPageMobile/style.ts
+++ b/src/features/rewards/mobile/settingsPageMobile/style.ts
@@ -4,7 +4,7 @@
 
 import styled from 'styled-components'
 
-export const StyledWrapper = styled<{}, 'div'>('div')`
+export const StyledWrapper = styled.div`
   background: ${p => p.theme.color.subtleBackground};
   min-height: 100vh;
   width: 100%;
@@ -12,7 +12,7 @@ export const StyledWrapper = styled<{}, 'div'>('div')`
   font-family: "Poppins", sans-serif
 `
 
-export const StyledContent = styled<{}, 'div'>('div')`
+export const StyledContent = styled.div`
    max-width: 1000px;
    margin: 0 auto;
    padding: 40px 10px 0 10px;

--- a/src/features/rewards/mobile/walletInfoHeader/style.ts
+++ b/src/features/rewards/mobile/walletInfoHeader/style.ts
@@ -5,7 +5,7 @@
 import styled from 'styled-components'
 import panelBgUrl from './assets/panel.svg'
 
-export const StyledWrapper = styled<{}, 'div'>('div')`
+export const StyledWrapper = styled.div`
   width: 100%;
   display: flex;
   border-radius: 6px;
@@ -17,12 +17,12 @@ export const StyledWrapper = styled<{}, 'div'>('div')`
   box-shadow: 0 1px 12px 0 rgba(99,105,110,0.18);
 `
 
-export const StyledHeader = styled<{}, 'div'>('div')`
+export const StyledHeader = styled.div`
   padding: 16px 21px 14px 19px;
   position: relative;
 `
 
-export const StyledTitle = styled<{}, 'div'>('div')`
+export const StyledTitle = styled.div`
   font-size: 16px;
   font-weight: 300;
   line-height: 1.38;
@@ -34,12 +34,12 @@ export const StyledTitle = styled<{}, 'div'>('div')`
   }
 `
 
-export const StyledBalance = styled<{}, 'div'>('div')`
+export const StyledBalance = styled.div`
   margin-top: -14px;
   text-align: center;
 `
 
-export const StyledBalanceTokens = styled<{}, 'div'>('div')`
+export const StyledBalanceTokens = styled.div`
   font-size: 38px;
   line-height: 0.61;
   letter-spacing: -0.4px;
@@ -48,7 +48,7 @@ export const StyledBalanceTokens = styled<{}, 'div'>('div')`
   margin-top: 10px;
 `
 
-export const StyledBalanceConverted = styled<{}, 'div'>('div')`
+export const StyledBalanceConverted = styled.div`
   font-family: Muli, sans-serif;
   font-size: 12px;
   line-height: 1.17;
@@ -57,7 +57,7 @@ export const StyledBalanceConverted = styled<{}, 'div'>('div')`
   margin: 8px 0;
 `
 
-export const StyledBalanceCurrency = styled<{}, 'span'>('span')`
+export const StyledBalanceCurrency = styled.span`
   text-transform: uppercase;
   opacity: 0.66;
   font-family: Muli, sans-serif;

--- a/src/features/rewards/modalActivity/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/modalActivity/__snapshots__/spec.tsx.snap
@@ -155,6 +155,7 @@ exports[`ModalActivity tests basic tests matches the snapshot 1`] = `
 }
 
 .c24 {
+  text-align: right;
   padding-right: 10px;
 }
 
@@ -445,7 +446,7 @@ exports[`ModalActivity tests basic tests matches the snapshot 1`] = `
                       className="c22"
                     >
                       <div
-                        className="c24 c23"
+                        className="c24"
                       >
                         MISSING: payment
                       </div>

--- a/src/features/rewards/modalActivity/style.ts
+++ b/src/features/rewards/modalActivity/style.ts
@@ -4,11 +4,11 @@
 
 import styled from 'styled-components'
 
-export const StyledWrapper = styled<{}, 'div'>('div')`
+export const StyledWrapper = styled.div`
   font-family: Poppins, sans-serif;
 `
 
-export const StyledTitle = styled<{}, 'div'>('div')`
+export const StyledTitle = styled.div`
   font-weight: 600;
   color: #1B1D2F;
   font-family: Poppins, sans-serif;
@@ -16,40 +16,40 @@ export const StyledTitle = styled<{}, 'div'>('div')`
   line-height: 2;
 `
 
-export const StyledSubTitle = styled<{}, 'span'>('span')`
+export const StyledSubTitle = styled.span`
   color: #838391;
   font-weight: normal;
 `
 
-export const StyledHeader = styled<{}, 'div'>('div')`
+export const StyledHeader = styled.div`
   display: flex;
   width: 100%;
   justify-content: space-between;
 `
 
-export const StyledLeft = styled<{}, 'div'>('div')`
+export const StyledLeft = styled.div`
   flex-basis: 40%;
 `
 
-export const StyledRight = styled<{}, 'div'>('div')`
+export const StyledRight = styled.div`
   flex-basis: 378px;
   flex-grow: 0;
   flex-shrink: 1;
   margin-bottom: 45px;
 `
 
-export const StyledSelectOption = styled<{}, 'div'>('div')`
+export const StyledSelectOption = styled.div`
   font-size: 22px;
   font-weight: 300;
   color: #4C54D2;
 `
 
-export const StyledIconWrap = styled<{}, 'div'>('div')`
+export const StyledIconWrap = styled.div`
   margin-bottom: 103px;
   display: flex;
 `
 
-export const StyledIcon = styled<{}, 'button'>('button')`
+export const StyledIcon = styled.button`
   display: flex;
   margin-right: 35px;
   background: none;
@@ -58,24 +58,24 @@ export const StyledIcon = styled<{}, 'button'>('button')`
   align-items: center;
 `
 
-export const StyledIconText = styled<{}, 'div'>('div')`
+export const StyledIconText = styled.div`
   font-size: 14px;
   line-height: 1.43;
   color: #838391;
   margin-left: 13px;
 `
 
-export const StyledBalance = styled<{}, 'div'>('div')`
+export const StyledBalance = styled.div`
   margin-top: 41px;
 `
 
-export const StyledTables = styled<{}, 'div'>('div')`
+export const StyledTables = styled.div`
   background-color: #f9f9fd;
   margin: 0 -50px;
   padding: 0 50px;
 `
 
-export const StyledWarning = styled<{}, 'div'>('div')`
+export const StyledWarning = styled.div`
   display: flex;
   justify-content: center;
   border-top: 1px solid #ebecf0;
@@ -84,7 +84,7 @@ export const StyledWarning = styled<{}, 'div'>('div')`
   align-items: flex-start;
 `
 
-export const StyledWarningText = styled<{}, 'div'>('div')`
+export const StyledWarningText = styled.div`
   max-width: 508px;
   font-family: Muli, sans-serif;
   font-size: 12px;
@@ -94,7 +94,7 @@ export const StyledWarningText = styled<{}, 'div'>('div')`
   padding-left: 8px;
 `
 
-export const StyledNote = styled<{}, 'div'>('div')`
+export const StyledNote = styled.div`
   max-width: 508px;
   margin-top: 46px;
   font-family: Muli, sans-serif;
@@ -104,7 +104,7 @@ export const StyledNote = styled<{}, 'div'>('div')`
   color: #686978;
 `
 
-export const StyledTableTitle = styled<{}, 'div'>('div')`
+export const StyledTableTitle = styled.div`
   display: flex;
   justify-content: space-between;
   font-size: 14px;
@@ -117,7 +117,7 @@ export const StyledTableTitle = styled<{}, 'div'>('div')`
   margin-top: 28px;
 `
 
-export const StyledTableSubTitle = styled<{}, 'div'>('div')`
+export const StyledTableSubTitle = styled.div`
   font-size: 14px;
   font-weight: 300;
   line-height: 2.79;
@@ -126,7 +126,7 @@ export const StyledTableSubTitle = styled<{}, 'div'>('div')`
   text-transform: none;
 `
 
-export const StyledVerified = styled<{}, 'div'>('div')`
+export const StyledVerified = styled.div`
   display: flex;
   font-size: 12px;
   align-items: center;
@@ -135,30 +135,30 @@ export const StyledVerified = styled<{}, 'div'>('div')`
   padding: 11px 0 32px;
 `
 
-export const StyledVerifiedText = styled<{}, 'div'>('div')`
+export const StyledVerifiedText = styled.div`
   margin-left: 5px;
 `
 
-export const StyledClosing = styled<{}, 'div'>('div')`
+export const StyledClosing = styled.div`
   margin-top: -10px;
 `
 
-export const StyledActionIcon = styled<{}, 'span'>('span')`
+export const StyledActionIcon = styled.span`
   color: #A1A8F2;
   width: 27px;
 `
 
-export const StyledAlertWrapper = styled<{}, 'div'>('div')`
+export const StyledAlertWrapper = styled.div`
   color: #E9AB18;
   width: 20px;
   margin-left: 3px;
 `
 
-export const StyledWarningWrapper = styled<{}, 'div'>('div')`
+export const StyledWarningWrapper = styled.div`
   display: flex;
 `
 
-export const StyledVerifiedIcon = styled<{}, 'div'>('div')`
+export const StyledVerifiedIcon = styled.div`
   display: flex;
   color: #392DD1;
   width: 19px;

--- a/src/features/rewards/modalAddFunds/style.ts
+++ b/src/features/rewards/modalAddFunds/style.ts
@@ -10,11 +10,11 @@ interface StyleProps {
   isMobile: boolean
 }
 
-export const StyledWrapper = styled<{}, 'div'>('div')`
+export const StyledWrapper = styled.div`
   font-family: Poppins, sans-serif;
 `
 
-export const StyledTitle = styled<{}, 'div'>('div')`
+export const StyledTitle = styled.div`
   font-size: 32px;
   font-weight: 500;
   color: #4b4c5c;
@@ -22,7 +22,7 @@ export const StyledTitle = styled<{}, 'div'>('div')`
   line-height: 1.3;
 `
 
-export const StyledNote = styled<{}, 'div'>('div') `
+export const StyledNote = styled.div`
   max-width: 508px;
   font-family: Muli,sans-serif;
   font-size: 12px;
@@ -31,14 +31,14 @@ export const StyledNote = styled<{}, 'div'>('div') `
   color: #686978;
 `
 
-export const StyledAddresses = styled<{}, 'div'>('div') `
+export const StyledAddresses = styled.div`
   display: flex;
   flex-wrap: wrap;
   margin: 0 -15px;
   align-items: stretch;
 `
 
-export const StyledAddress = styled<StyleProps, 'div'>('div') `
+export const StyledAddress = styled.div<StyleProps> `
   flex-basis: ${p => p.isMobile ? 100 : 50}%;
   flex-shrink: 0;
   flex-grow: 0;
@@ -47,21 +47,21 @@ export const StyledAddress = styled<StyleProps, 'div'>('div') `
   padding: 0 15px 26px;
 `
 
-export const StyledLogo = styled<{}, 'div'>('div') `
+export const StyledLogo = styled.div`
   height: 60px;
   flex-basis: 60px;
   flex-shrink: 0;
   margin-right: 20px;
 `
 
-export const StyledData = styled<{}, 'div'>('div') `
+export const StyledData = styled.div`
   flex-basis: 100%;
   text-align: center;
   margin-top: 22px;
   color: #686978;
 `
 
-export const StyledAddressTitle = styled<{}, 'div'>('div') `
+export const StyledAddressTitle = styled.div`
   flex-basis: 30%;
   flex-grow: 1;
   font-size: 16px;
@@ -69,7 +69,7 @@ export const StyledAddressTitle = styled<{}, 'div'>('div') `
   color: #4b4c5c;
 `
 
-export const StyledShowQR = styled<{}, 'div'>('div') `
+export const StyledShowQR = styled.div`
   width: 110px;
   height: 110px;
   justify-content: center;
@@ -77,7 +77,7 @@ export const StyledShowQR = styled<{}, 'div'>('div') `
   background: #eee;
 `
 
-export const StyledQRImageWrapper = styled<{}, 'div'>('div') `
+export const StyledQRImageWrapper = styled.div`
   flex-basis: 100%;
   justify-content: center;
   display: flex;
@@ -85,7 +85,7 @@ export const StyledQRImageWrapper = styled<{}, 'div'>('div') `
   position: relative;
 `
 
-export const StyledQRImage = styled<{}, 'img'>('img') `
+export const StyledQRImage = styled.img `
   width: 110px;
   height: 110px;
 `
@@ -96,7 +96,7 @@ export const StyledQRButton = styled(Button as ComponentType<ButtonProps>) `
   font-weight: 400;
 `
 
-export const StyledLink = styled<{}, 'a'>('a') `
+export const StyledLink = styled.a `
   color: #4c54d2;
   text-decoration: none;
 
@@ -105,13 +105,13 @@ export const StyledLink = styled<{}, 'a'>('a') `
   }
 `
 
-export const StyledHeader = styled<{}, 'div'>('div') `
+export const StyledHeader = styled.div`
   display: flex;
   align-items: center;
   flex-wrap: wrap;
 `
 
-export const StyledWalletAddress = styled<{}, 'div'>('div') `
+export const StyledWalletAddress = styled.div`
   font-size: 12px;
   font-weight: 500;
   line-height: 1;
@@ -120,7 +120,7 @@ export const StyledWalletAddress = styled<{}, 'div'>('div') `
   margin-bottom: 4px;
 `
 
-export const StyledText = styled<{}, 'p'>('p') `
+export const StyledText = styled.p `
   margin-bottom: 30px;
   padding: 0;
   font-size: 15px;

--- a/src/features/rewards/modalBackupRestore/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/modalBackupRestore/__snapshots__/spec.tsx.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ModalBackupRestore tests basic tests matches the snapshot 1`] = `
-.c26 {
-  --button-main-color: #ff7654;
-  --button-main-color-hover: #FB542B;
-  --button-main-color-active: #ffb8a6;
+.c27 {
+  --button-main-color: #FB542B;
+  --button-main-color-hover: #F43405;
+  --button-main-color-active: #FDBBAA;
   --button-state-color: var(--button-main-color);
   --icon-size: 16px;
   --icon-spacing: 6px;
@@ -39,28 +39,70 @@ exports[`ModalBackupRestore tests basic tests matches the snapshot 1`] = `
   width: auto;
   min-width: 104px;
   padding: 11px 15px;
-}
-
-.c26:hover:enabled {
-  --button-state-color: var(--button-main-color-hover);
-}
-
-.c26:active:enabled {
-  --button-state-color: var(--button-main-color-active);
-}
-
-.c28 {
   color: #fff;
   background: var(--button-state-color);
   border: 1px solid var(--button-state-color);
 }
 
+.c27:hover:enabled {
+  --button-state-color: var(--button-main-color-hover);
+}
+
+.c27:active:enabled {
+  --button-state-color: var(--button-main-color-active);
+}
+
 .c25 {
+  --button-main-color: #FB542B;
+  --button-main-color-hover: #F43405;
+  --button-main-color-active: #FDBBAA;
+  --button-state-color: var(--button-main-color);
+  --icon-size: 16px;
+  --icon-spacing: 6px;
+  --webkit-appearance: none;
+  box-sizing: border-box;
+  background: none;
+  border: none;
+  outline-color: transparent;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row-reverse;
+  -ms-flex-direction: row-reverse;
+  flex-direction: row-reverse;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-family: Poppins,sans-serif;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  font-size: 13px;
+  border-radius: 20px;
+  width: auto;
+  min-width: 104px;
+  padding: 11px 15px;
   border: 1px solid;
   color: var(--button-state-color);
 }
 
-.c27 {
+.c25:hover:enabled {
+  --button-state-color: var(--button-main-color-hover);
+}
+
+.c25:active:enabled {
+  --button-state-color: var(--button-main-color-active);
+}
+
+.c26 {
   min-height: var(--icon-size);
   display: -webkit-box;
   display: -webkit-flex;
@@ -438,13 +480,13 @@ exports[`ModalBackupRestore tests basic tests matches the snapshot 1`] = `
         className="c23"
       >
         <button
-          className="c24 c25 c26"
+          className="c24 c25"
           onClick={[Function]}
           size="medium"
           type="accent"
         >
           <div
-            className="c27"
+            className="c26"
             size="medium"
             type="accent"
           >
@@ -452,13 +494,13 @@ exports[`ModalBackupRestore tests basic tests matches the snapshot 1`] = `
           </div>
         </button>
         <button
-          className="c24 c28 c26"
+          className="c24 c27"
           onClick={[Function]}
           size="medium"
           type="accent"
         >
           <div
-            className="c27"
+            className="c26"
             size="medium"
             type="accent"
           >

--- a/src/features/rewards/modalBackupRestore/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/modalBackupRestore/__snapshots__/spec.tsx.snap
@@ -2,9 +2,9 @@
 
 exports[`ModalBackupRestore tests basic tests matches the snapshot 1`] = `
 .c27 {
-  --button-main-color: #FB542B;
-  --button-main-color-hover: #F43405;
-  --button-main-color-active: #FDBBAA;
+  --button-main-color: #ff7654;
+  --button-main-color-hover: #FB542B;
+  --button-main-color-active: #ffb8a6;
   --button-state-color: var(--button-main-color);
   --icon-size: 16px;
   --icon-spacing: 6px;
@@ -53,9 +53,9 @@ exports[`ModalBackupRestore tests basic tests matches the snapshot 1`] = `
 }
 
 .c25 {
-  --button-main-color: #FB542B;
-  --button-main-color-hover: #F43405;
-  --button-main-color-active: #FDBBAA;
+  --button-main-color: #ff7654;
+  --button-main-color-hover: #FB542B;
+  --button-main-color-active: #ffb8a6;
   --button-state-color: var(--button-main-color);
   --icon-size: 16px;
   --icon-spacing: 6px;

--- a/src/features/rewards/modalBackupRestore/style.ts
+++ b/src/features/rewards/modalBackupRestore/style.ts
@@ -10,7 +10,7 @@ interface StyleProps {
   error?: boolean
 }
 
-export const StyledContent = styled<{}, 'div'>('div')`
+export const StyledContent = styled.div`
   font-size: 14px;
   font-family: Muli, sans-serif;
   letter-spacing: 0;
@@ -19,12 +19,12 @@ export const StyledContent = styled<{}, 'div'>('div')`
   margin-top: 40px;
 `
 
-export const StyledImport = styled<{}, 'label'>('label')`
+export const StyledImport = styled.label`
   color: #4c54d2;
   cursor: pointer;
 `
 
-export const StyleButtonWrapper = styled<{}, 'div'>('div')`
+export const StyleButtonWrapper = styled.div`
   display: flex;
   margin-top: 20px;
   justify-content: center;
@@ -43,19 +43,19 @@ export const GroupedButton = styled(Button as ComponentType<ButtonProps>)`
   }
 `
 
-export const StyledDoneWrapper = styled<{}, 'div'>('div')`
+export const StyledDoneWrapper = styled.div`
   display: flex;
   justify-content: center;
   margin-top: 40px;
 `
 
-export const StyledStatus = styled<StyleProps, 'div'>('div')`
+export const StyledStatus = styled.div<StyleProps>`
   margin: ${p => p.isError ? 0 : -16}px 0 16px;
   border-radius: 6px;
   overflow: hidden;
 `
 
-export const StyledActionsWrapper = styled<{}, 'div'>('div')`
+export const StyledActionsWrapper = styled.div`
   margin-top: 40px;
   display: flex;
   justify-content: center;
@@ -65,13 +65,13 @@ export const ActionButton = styled(Button as ComponentType<ButtonProps>)`
   margin: 0 8px;
 `
 
-export const StyledTitleWrapper = styled<{}, 'div'>('div')`
+export const StyledTitleWrapper = styled.div`
   width: 100%;
   text-align: center;
   margin-bottom: 20px;
 `
 
-export const StyledTitle = styled<{}, 'span'>('span')`
+export const StyledTitle = styled.span`
   font-size: 22px;
   font-weight: normal;
   letter-spacing: 0;
@@ -79,23 +79,23 @@ export const StyledTitle = styled<{}, 'span'>('span')`
   font-family: ${p => p.theme.fontFamily.heading};
 `
 
-export const StyledSafe = styled<{}, 'span'>('span')`
+export const StyledSafe = styled.span`
   font-weight: 700;
   margin-right: 3px;
   color: ${p => p.theme.color.brandBatInteracting};
 `
 
-export const StyledTabWrapper = styled<{}, 'div'>('div')`
+export const StyledTabWrapper = styled.div`
   margin: 0 auto;
   max-width: 400px;
 `
 
-export const StyledControlWrapper = styled<{}, 'div'>('div')`
+export const StyledControlWrapper = styled.div`
   width: 100%;
   margin-bottom: 30px;
 `
 
-export const StyledText = styled<{}, 'p'>('p')`
+export const StyledText = styled.p`
   font-size: 16px;
   font-weight: 200;
   letter-spacing: 0;
@@ -103,6 +103,6 @@ export const StyledText = styled<{}, 'p'>('p')`
   font-family: Muli, sans-serif;
 `
 
-export const StyledTextWrapper = styled<{}, 'div'>('div')`
+export const StyledTextWrapper = styled.div`
   margin-bottom: 25px;
 `

--- a/src/features/rewards/modalContribute/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/modalContribute/__snapshots__/spec.tsx.snap
@@ -71,6 +71,7 @@ exports[`ModalContribute tests basic tests matches the snapshot 1`] = `
 }
 
 .c12 {
+  text-align: right;
   padding-right: 10px;
 }
 
@@ -177,7 +178,7 @@ exports[`ModalContribute tests basic tests matches the snapshot 1`] = `
                     className="c10"
                   >
                     <div
-                      className="c12 c11"
+                      className="c12"
                     >
                       
                     </div>

--- a/src/features/rewards/modalContribute/style.ts
+++ b/src/features/rewards/modalContribute/style.ts
@@ -4,24 +4,24 @@
 
 import styled from 'styled-components'
 
-export const StyledWrapper = styled<{}, 'div'>('div')`
+export const StyledWrapper = styled.div`
   font-family: Poppins, sans-serif;
 `
 
-export const StyledTitle = styled<{}, 'div'>('div')`
+export const StyledTitle = styled.div`
   font-size: 16px;
   font-weight: 600;
   line-height: 2;
   color: #4b4c5c;
 `
 
-export const StyledContent = styled<{}, 'div'>('div')`
+export const StyledContent = styled.div`
   font-size: 28px;
   color: #696fdc;
   margin-bottom: 33px;
 `
 
-export const StyledNum = styled<{}, 'span'>('span')`
+export const StyledNum = styled.span`
   font-weight: 500;
   color: #0c0d21;
 `

--- a/src/features/rewards/modalDonation/style.ts
+++ b/src/features/rewards/modalDonation/style.ts
@@ -4,11 +4,11 @@
 
 import styled from 'styled-components'
 
-export const StyledWrapper = styled<{}, 'div'>('div')`
+export const StyledWrapper = styled.div`
   font-family: Poppins, sans-serif;
 `
 
-export const StyledTitle = styled<{}, 'div'>('div')`
+export const StyledTitle = styled.div`
   font-size: 20px;
   font-weight: 600;
   line-height: 2;

--- a/src/features/rewards/nextContribution/style.ts
+++ b/src/features/rewards/nextContribution/style.ts
@@ -4,7 +4,7 @@
 
 import styled from 'styled-components'
 
-export const StyledWrapper = styled<{}, 'div'>('div')`
+export const StyledWrapper = styled.div`
   font-size: 14px;
   text-align: right;
   border-radius: 6px;

--- a/src/features/rewards/panelWelcome/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/panelWelcome/__snapshots__/spec.tsx.snap
@@ -1,22 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PanelWelcome tests basic tests matches the snapshot 1`] = `
-.c7 {
+.c6 {
   box-sizing: border-box;
   font-family: Poppins,sans-serif;
   font-weight: 400;
   -webkit-font-smoothing: antialiased;
   margin: 0;
-}
-
-.c6 {
   font-size: 24px;
 }
 
-.c12 {
-  --button-main-color: #c2c4cf;
-  --button-main-color-hover: #AEB1C2;
-  --button-main-color-active: #84889c;
+.c10 {
+  --button-main-color: #A0A1B2;
+  --button-main-color-hover: #7C7D8C;
+  --button-main-color-active: #585968;
   --button-state-color: var(--button-main-color);
   --icon-size: 18px;
   --icon-spacing: 6px;
@@ -51,22 +48,19 @@ exports[`PanelWelcome tests basic tests matches the snapshot 1`] = `
   width: 100%;
   min-width: 235px;
   padding: 19px 15px;
-}
-
-.c12:hover:enabled {
-  --button-state-color: var(--button-main-color-hover);
-}
-
-.c12:active:enabled {
-  --button-state-color: var(--button-main-color-active);
-}
-
-.c11 {
   border: 1px solid;
   color: var(--button-state-color);
 }
 
-.c13 {
+.c10:hover:enabled {
+  --button-state-color: var(--button-main-color-hover);
+}
+
+.c10:active:enabled {
+  --button-state-color: var(--button-main-color-active);
+}
+
+.c11 {
   min-height: var(--icon-size);
   display: -webkit-box;
   display: -webkit-flex;
@@ -130,7 +124,7 @@ exports[`PanelWelcome tests basic tests matches the snapshot 1`] = `
   display: inline-block;
 }
 
-.c9 {
+.c8 {
   color: #FFFFFF;
   font-size: 16px;
   font-weight: normal;
@@ -146,17 +140,17 @@ exports[`PanelWelcome tests basic tests matches the snapshot 1`] = `
   font-family: Muli,sans-serif;
 }
 
-.c10 {
+.c9 {
   color: #FFF;
   margin: 0 auto 24px;
   outline: 0;
 }
 
-.c10:hover {
+.c9:hover {
   color: #e0e0e0;
 }
 
-.c14 {
+.c12 {
   color: #73CBFF;
   font-size: 14px;
   font-weight: 500;
@@ -171,7 +165,7 @@ exports[`PanelWelcome tests basic tests matches the snapshot 1`] = `
   margin: 0 0 16px;
 }
 
-.c8 {
+.c7 {
   display: inline-block;
   vertical-align: text-top;
   margin-top: -13px;
@@ -231,27 +225,27 @@ exports[`PanelWelcome tests basic tests matches the snapshot 1`] = `
       </svg>
     </span>
     <h4
-      className="c5 c6 c7"
+      className="c5 c6"
     >
       MISSING: braveRewards
     </h4>
     <span
-      className="c8"
+      className="c7"
     >
       TM
     </span>
     <p
-      className="c9"
+      className="c8"
     >
       MISSING: welcomeDescOne
     </p>
     <button
-      className="c10 c11 c12"
+      className="c9 c10"
       size="call-to-action"
       type="subtle"
     >
       <div
-        className="c13"
+        className="c11"
         size="call-to-action"
         type="subtle"
       >
@@ -259,7 +253,7 @@ exports[`PanelWelcome tests basic tests matches the snapshot 1`] = `
       </div>
     </button>
     <div
-      className="c14"
+      className="c12"
     >
       MISSING: welcomeFooterTextOne
     </div>

--- a/src/features/rewards/panelWelcome/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/panelWelcome/__snapshots__/spec.tsx.snap
@@ -11,9 +11,9 @@ exports[`PanelWelcome tests basic tests matches the snapshot 1`] = `
 }
 
 .c10 {
-  --button-main-color: #A0A1B2;
-  --button-main-color-hover: #7C7D8C;
-  --button-main-color-active: #585968;
+  --button-main-color: #c2c4cf;
+  --button-main-color-hover: #AEB1C2;
+  --button-main-color-active: #84889c;
   --button-state-color: var(--button-main-color);
   --icon-size: 18px;
   --icon-spacing: 6px;

--- a/src/features/rewards/panelWelcome/style.ts
+++ b/src/features/rewards/panelWelcome/style.ts
@@ -8,20 +8,20 @@ import batOutlineUrl from './assets/batOutline.svg'
 import Button, { Props as ButtonProps } from '../../../components/buttonsIndicators/button'
 import { ComponentType } from 'react'
 
-export const StyledWrapper = styled<{}, 'div'>('div')`
+export const StyledWrapper = styled.div`
   text-align: center;
   font-family: Poppins, sans-serif;
   background-image: linear-gradient(140deg, #392DD1 0%, #8E2995 100%);
 ` as any
 
-export const StyledInnerWrapper = styled<{}, 'div'>('div')`
+export const StyledInnerWrapper = styled.div`
   margin: 0 auto;
   display: inline-block;
   padding: 35px 30px 25px;
   background: url(${batOutlineUrl}) no-repeat top;
 ` as any
 
-export const StyledHeaderText = styled<{}, 'p'>('p')`
+export const StyledHeaderText = styled.p`
   width: 261px;
   color: #FFFFFF;
   font-size: 16px;
@@ -33,7 +33,7 @@ export const StyledHeaderText = styled<{}, 'p'>('p')`
   font-family: Muli, sans-serif;
 ` as any
 
-export const StyledBatLogo = styled<{}, 'span'>('span')`
+export const StyledBatLogo = styled.span`
   display: block;
   margin: -10px auto 2px;
   width: 150px;
@@ -49,7 +49,7 @@ export const StyledTitle = styled(Heading)`
   display: inline-block;
 ` as any
 
-export const StyledDescText = styled<{}, 'p'>('p')`
+export const StyledDescText = styled.p`
   color: #FFFFFF;
   font-size: 16px;
   font-weight: normal;
@@ -71,7 +71,7 @@ export const StyledJoinButton = styled(Button as ComponentType<ButtonProps>)`
   }
 ` as any
 
-export const StyledFooterText = styled<{}, 'div'>('div')`
+export const StyledFooterText = styled.div`
   color: #73CBFF;
   font-size: 14px;
   font-weight: 500;
@@ -83,7 +83,7 @@ export const StyledFooterText = styled<{}, 'div'>('div')`
   margin: 0 0 16px;
 ` as any
 
-export const StyledTrademark = styled<{}, 'span'>('span')`
+export const StyledTrademark = styled.span`
   display: inline-block;
   vertical-align: text-top;
   margin-top: -13px;
@@ -93,7 +93,7 @@ export const StyledTrademark = styled<{}, 'span'>('span')`
   opacity: 0.7;
 ` as any
 
-export const StyledErrorMessage = styled<{}, 'span'>('span')`
+export const StyledErrorMessage = styled.span`
   font-size: 16px;
   display: block;
   margin: 0px auto 20px;

--- a/src/features/rewards/profile/style.ts
+++ b/src/features/rewards/profile/style.ts
@@ -17,7 +17,7 @@ const getOverflowRules = (provider?: Provider) => {
   `
 }
 
-export const StyledWrapper = styled<{}, 'div'>('div')`
+export const StyledWrapper = styled.div`
   position: relative;
   display: flex;
   justify-content: space-between;
@@ -27,7 +27,7 @@ export const StyledWrapper = styled<{}, 'div'>('div')`
   font-family: Poppins, sans-serif;
 `
 
-export const StyledImageWrapper = styled<Partial<Props>, 'div'>('div')`
+export const StyledImageWrapper = styled.div<Partial<Props>>`
   flex-basis: 30px;
   position: relative;
 
@@ -46,7 +46,7 @@ export const StyledImageWrapper = styled<Partial<Props>, 'div'>('div')`
   };
 `
 
-export const StyledImage = styled<Partial<Props>, 'img'>('img')`
+export const StyledImage = styled.img<Partial<Props>>`
   border-radius: 50%;
 
   ${p => p.type === 'big'
@@ -66,7 +66,7 @@ export const StyledImage = styled<Partial<Props>, 'img'>('img')`
   };
 `
 
-export const StyledVerified = styled<{}, 'span'>('span')`
+export const StyledVerified = styled.span`
   position: absolute;
   top: -5px;
   right: -8px;
@@ -78,7 +78,7 @@ export const StyledVerified = styled<{}, 'span'>('span')`
   padding: 1px;
 `
 
-export const StyledContent = styled<Partial<Props>, 'div'>('div')`
+export const StyledContent = styled.div<Partial<Props>>`
   flex-grow: 1;
   flex-shrink: 1;
   flex-basis: 50%;
@@ -86,14 +86,14 @@ export const StyledContent = styled<Partial<Props>, 'div'>('div')`
   padding-left: ${p => p.type === 'big' ? '11px' : 0};
 `
 
-export const StyledTitleWrap = styled<Partial<Props>, 'div'>('div')`
+export const StyledTitleWrap = styled.div<Partial<Props>>`
   ${p => getOverflowRules(p.provider)}
   max-width: ${p => p.tableCell ? 235 : 260}px;
   margin-top: ${p => p.type === 'big' ? 2 : 0}px;
   margin-left: ${p => p.type !== 'big' ? 10 : 0}px;
 `
 
-export const StyledTitle = styled<Partial<Props>, 'span'>('span')`
+export const StyledTitle = styled.span<Partial<Props>>`
   ${p => p.type === 'big'
     ? css`
       font-size: 18px;
@@ -118,7 +118,7 @@ export const StyledTitle = styled<Partial<Props>, 'span'>('span')`
   };
 `
 
-export const StyledProvider = styled<Partial<Props>, 'span'>('span')`
+export const StyledProvider = styled.span<Partial<Props>>`
   padding-left: 5px;
 
   ${p => p.type === 'big'
@@ -133,13 +133,13 @@ export const StyledProvider = styled<Partial<Props>, 'span'>('span')`
   color: ${p => p.type === 'big' ? '#4b4c5c' : '#b8b9c4'};
 `
 
-export const StyledProviderWrap = styled<{}, 'div'>('div')`
+export const StyledProviderWrap = styled.div`
   display: flex;
   align-items: center;
   margin-bottom: -4px;
 `
 
-export const StyledVerifiedText = styled<{}, 'span'>('span')`
+export const StyledVerifiedText = styled.span`
   font-size: 12px;
   color: #838391;
   font-weight: 400;
@@ -147,20 +147,20 @@ export const StyledVerifiedText = styled<{}, 'span'>('span')`
   margin-left: 4px;
 `
 
-export const StyledInlineVerified = styled<{}, 'span'>('span')`
+export const StyledInlineVerified = styled.span`
   width: 19px;
   padding-top: 2px;
   margin-left: -2px;
   color: #392DD1;
 `
 
-export const StyledInlineUnVerified = styled<{}, 'span'>('span')`
+export const StyledInlineUnVerified = styled.span`
   width: 19px;
   padding-top: 2px;
   margin-left: -2px;
   color: #D0D4D9;
 `
 
-export const StyledSubTitle = styled<{}, 'span'>('span')`
+export const StyledSubTitle = styled.span`
   margin-top: 5px;
 `

--- a/src/features/rewards/restoreSites/style.ts
+++ b/src/features/rewards/restoreSites/style.ts
@@ -5,7 +5,7 @@
 
 import styled from 'styled-components'
 
-export const StyledExcludedText = styled<{}, 'div'>('div')`
+export const StyledExcludedText = styled.div`
   color: #4B4C5C;
   font-size: 14px;
   font-weight: 300;
@@ -15,7 +15,7 @@ export const StyledExcludedText = styled<{}, 'div'>('div')`
   margin-bottom: 33px;
 `
 
-export const StyledRestore = styled<{}, 'a'>('a')`
+export const StyledRestore = styled.a`
   color: #696fdc;
   display: inline-block;
   font-size: 13px;

--- a/src/features/rewards/rewardsButton/style.ts
+++ b/src/features/rewards/rewardsButton/style.ts
@@ -56,7 +56,7 @@ const getTypeStyle = (type?: Type, disabled?: boolean) => {
   return typeCss
 }
 
-export const StyledButtonWrapper = styled<StyleProps, 'button'>('button')`
+export const StyledButtonWrapper = styled.button<StyleProps>`
   width: 100%;
   display: flex;
   color: white;
@@ -72,7 +72,7 @@ export const StyledButtonWrapper = styled<StyleProps, 'button'>('button')`
   }
 `
 
-export const StyledButtonText = styled<{}, 'span'>('span')`
+export const StyledButtonText = styled.span`
   font-family: Poppins, sans-serif;
   font-weight: 600;
   text-transform: uppercase;
@@ -80,7 +80,7 @@ export const StyledButtonText = styled<{}, 'span'>('span')`
   margin: 0 auto;
 `
 
-export const StyledIcon = styled<{}, 'div'>('div')`
+export const StyledIcon = styled.div`
   display: inline-block;
   line-height: 0;
   height: 18px;

--- a/src/features/rewards/settingsPage/style.ts
+++ b/src/features/rewards/settingsPage/style.ts
@@ -4,14 +4,14 @@
 
 import styled from 'styled-components'
 
-export const StyledWrapper = styled<{}, 'div'>('div')`
+export const StyledWrapper = styled.div`
   background: #f2f4f7;
   min-height: 100vh;
   min-width: 1024px;
   font-family: "Poppins", sans-serif
 `
 
-export const StyledContent = styled<{}, 'div'>('div')`
+export const StyledContent = styled.div`
  max-width: 1000px;
  margin: 0 auto;
  padding: 40px 0;

--- a/src/features/rewards/siteBanner/style.ts
+++ b/src/features/rewards/siteBanner/style.ts
@@ -43,14 +43,14 @@ const getDonationStyle = (isMobile?: boolean) => {
   `
 }
 
-export const StyledWrapper = styled<StyleProps, 'div'>('div')`
+export const StyledWrapper = styled.div<StyleProps>`
   overflow-y: scroll;
   height: ${p => p.isMobile ? 'calc(100% - 237px)' : 'auto'};
   padding: ${p => p.isMobile ? '10px 15' : 0}px;
   font-family: Poppins, sans-serif;
 `
 
-export const StyledContentWrapper = styled<StyleProps, 'div'>('div')`
+export const StyledContentWrapper = styled.div<StyleProps>`
   display: ${p => p.isMobile ? 'block' : 'flex'};
   justify-content: space-between;
   align-items: stretch;
@@ -60,7 +60,7 @@ export const StyledContentWrapper = styled<StyleProps, 'div'>('div')`
   margin: 0 auto;
 `
 
-export const StyledContent = styled<{}, 'div'>('div')`
+export const StyledContent = styled.div`
   flex-grow: 1;
   flex-shrink: 1;
   flex-basis: calc(100% - 336px);
@@ -71,7 +71,7 @@ export const StyledContent = styled<{}, 'div'>('div')`
   align-content: space-between;
 `
 
-export const StyledDonation = styled<StyleProps, 'div'>('div')`
+export const StyledDonation = styled.div<StyleProps>`
   flex-basis: 336px;
   background: #696fdc;
   justify-content: space-between;
@@ -80,13 +80,13 @@ export const StyledDonation = styled<StyleProps, 'div'>('div')`
   ${p => getDonationStyle(p.isMobile)}
 `
 
-export const StyledBanner = styled<StyleProps, 'div'>('div')`
+export const StyledBanner = styled.div<StyleProps>`
   position: relative;
   min-width: ${p => p.isMobile ? 'unset' : '900px'};
   background: #DBE3F3;
 `
 
-export const StyledBannerImage = styled<Partial<Props>, 'div'>('div')`
+export const StyledBannerImage = styled.div<Partial<Props>>`
   font-size: ${p => !p.bgImage ? '38px' : 0};
   font-weight: 600;
   line-height: 0.74;
@@ -98,7 +98,7 @@ export const StyledBannerImage = styled<Partial<Props>, 'div'>('div')`
   };
 `
 
-export const StyledClose = styled<{}, 'button'>('button')`
+export const StyledClose = styled.button`
   top: 16px;
   right: 16px;
   position: absolute;
@@ -112,12 +112,12 @@ export const StyledClose = styled<{}, 'button'>('button')`
   filter: drop-shadow(0px 0px 2px rgba(0, 0, 0, .4));
 `
 
-export const StyledLogoWrapper = styled<StyleProps, 'div'>('div')`
+export const StyledLogoWrapper = styled.div<StyleProps>`
   padding-left: ${p => p.isMobile ? 20 : 45}px;
   flex-basis: 217px;
 `
 
-export const StyledLogoText = styled<StyleProps, 'div'>('div')`
+export const StyledLogoText = styled.div<StyleProps>`
   background: inherit;
   -webkit-background-clip: text;
   color: transparent;
@@ -132,7 +132,7 @@ export const StyledLogoText = styled<StyleProps, 'div'>('div')`
   margin-top: ${p => p.isMobile ? -15 : 0}px;
 `
 
-export const StyledLogoBorder = styled<StyleProps, 'div'>('div')`
+export const StyledLogoBorder = styled.div<StyleProps>`
   border: 6px solid #fff;
   border-radius: 50%;
   width: ${p => p.isMobile ? 100 : 160}px;
@@ -143,11 +143,11 @@ export const StyledLogoBorder = styled<StyleProps, 'div'>('div')`
   overflow: hidden;
 `
 
-export const StyledTextWrapper = styled<StyleProps, 'div'>('div')`
+export const StyledTextWrapper = styled.div<StyleProps>`
   ${p => getTextStyle(p.isMobile)}
 `
 
-export const StyledTitle = styled<StyleProps, 'div'>('div')`
+export const StyledTitle = styled.div<StyleProps>`
   font-size: 28px;
   font-weight: 600;
   line-height: 1;
@@ -156,7 +156,7 @@ export const StyledTitle = styled<StyleProps, 'div'>('div')`
   padding-left: ${p => p.isMobile ? 25 : 0}px;
 `
 
-export const StyledText = styled<StyleProps, 'div'>('div')`
+export const StyledText = styled.div<StyleProps>`
   font-family: Muli, sans-serif;
   font-size: 16px;
   line-height: 1.5;
@@ -165,7 +165,7 @@ export const StyledText = styled<StyleProps, 'div'>('div')`
   padding-left: ${p => p.isMobile ? 25 : 0}px;
 `
 
-export const StyledWallet = styled<StyleProps, 'div'>('div')`
+export const StyledWallet = styled.div<StyleProps>`
   font-size: 12px;
   color: #afb2f1;
   text-align: right;
@@ -173,22 +173,22 @@ export const StyledWallet = styled<StyleProps, 'div'>('div')`
   padding: 0 ${p => p.isMobile ? 20 : 19}px 0 55px;
 `
 
-export const StyledTokens = styled<{}, 'span'>('span')`
+export const StyledTokens = styled.span`
   color: #fff;
 `
 
-export const StyledOption = styled<{}, 'span'>('span')`
+export const StyledOption = styled.span`
   color: rgba(255, 255, 255, 0.65);
 `
 
-export const StyledCenter = styled<{}, 'div'>('div')`
+export const StyledCenter = styled.div`
   max-width: 1024px;
   padding: 126px 0 0 238px;
   margin: 0 auto;
   user-select: none;
 `
 
-export const StyledSocialItem = styled<{}, 'a'>('a')`
+export const StyledSocialItem = styled.a`
   font-size: 12px;
   line-height: 2.5;
   letter-spacing: 0.2px;
@@ -198,7 +198,7 @@ export const StyledSocialItem = styled<{}, 'a'>('a')`
   margin: 0 8px;
 `
 
-export const StyledSocialIcon = styled<{}, 'span'>('span')`
+export const StyledSocialIcon = styled.span`
   vertical-align: middle;
   display: inline-block;
   margin-right: 5px;
@@ -206,30 +206,30 @@ export const StyledSocialIcon = styled<{}, 'span'>('span')`
   height: 22px;
 `
 
-export const StyledSocialWrapper = styled<StyleProps, 'div'>('div')`
+export const StyledSocialWrapper = styled.div<StyleProps>`
   text-align: right;
   padding-right: ${p => p.isMobile ? 0 : 40}px;
   margin-top: ${p => p.isMobile ? 5 : 15}px;
 `
 
-export const StyledEmptyBox = styled<{}, 'div'>('div')`
+export const StyledEmptyBox = styled.div`
   width: 100%;
   height: 39px;
 `
 
-export const StyledLogoImage = styled<StyleProps, 'div'>('div')`
+export const StyledLogoImage = styled.div<StyleProps>`
   width: 148px;
   height: 148px;
   background: url(${p => p.bg}) no-repeat;
   background-size: cover;
 `
 
-export const StyledCheckbox = styled<StyleProps, 'div'>('div')`
+export const StyledCheckbox = styled.div<StyleProps>`
   width: ${p => p.isMobile ? 232 : 180}px;
   padding-left: ${p => p.isMobile ? 40 : 0}px;
   margin: ${p => p.isMobile ? '15px auto 5px auto' : '15px 0 5px'};
 `
-export const StyledNoticeWrapper = styled<{}, 'div'>('div')`
+export const StyledNoticeWrapper = styled.div`
   background: #fff;
   border: 1px solid rgba(155, 157, 192, 0);
   border-radius: 4px;
@@ -238,13 +238,13 @@ export const StyledNoticeWrapper = styled<{}, 'div'>('div')`
   padding: 7px 15px;
   display: flex;
 `
-export const StyledNoticeIcon = styled<{}, 'div'>('div')`
+export const StyledNoticeIcon = styled.div`
   width: 39px;
   height: 39px;
   color: #00AEFF;
   margin: -2px 6px 0 0;
 `
-export const StyledNoticeText = styled<{}, 'div'>('div')`
+export const StyledNoticeText = styled.div`
   flex: 1;
   color: #67667D;
   font-size: 12px;
@@ -252,7 +252,7 @@ export const StyledNoticeText = styled<{}, 'div'>('div')`
   letter-spacing: 0;
   line-height: 18px;
 `
-export const StyledNoticeLink = styled<{}, 'a'>('a')`
+export const StyledNoticeLink = styled.a`
   color: #0095FF;
   font-family: ${p => p.theme.fontFamily.body};
   font-weight: bold;

--- a/src/features/rewards/tab/style.ts
+++ b/src/features/rewards/tab/style.ts
@@ -10,12 +10,12 @@ interface StyleProps {
   selected?: boolean
 }
 
-export const RewardsTabWrapper = styled<{}, 'div'>('div')`
+export const RewardsTabWrapper = styled.div`
   display: flex;
   font-family: Poppins,sans-serif;
 `
 
-export const StyledSwitch = styled<{}, 'div'>('div')`
+export const StyledSwitch = styled.div`
   position: relative;
   display: block;
   width: 100%;
@@ -23,14 +23,14 @@ export const StyledSwitch = styled<{}, 'div'>('div')`
   cursor: pointer;
 `
 
-export const StyledSlider = styled<{}, 'div'>('div')`
+export const StyledSlider = styled.div`
   width: 100%;
   height: 100%;
   background: #DFDFE8;
   border-radius: 21.5px 21.5px 21.5px 21.5px;
 `
 
-export const StyledBullet = styled<Props, 'div'>('div')`
+export const StyledBullet = styled.div<Props>`
   top: -17px;
   width: 50%;
   height: 37px;
@@ -42,14 +42,14 @@ export const StyledBullet = styled<Props, 'div'>('div')`
   box-shadow: 0 3px 3px rgba(0, 0, 0, 0.05);
 `
 
-export const StyledTab = styled<StyleProps, 'div'>('div')`
+export const StyledTab = styled.div<StyleProps>`
   width: 50%;
   display: block;
   height: 100%;
   float: ${p => p.left ? 'left' : 'right'};
 `
 
-export const StyledText = styled<StyleProps, 'div'>('div')`
+export const StyledText = styled.div<StyleProps>`
   z-index: 9;
   position: relative;
   font-size: 14px;

--- a/src/features/rewards/tableContribute/style.ts
+++ b/src/features/rewards/tableContribute/style.ts
@@ -4,7 +4,7 @@
 
 import styled from 'styled-components'
 
-export const StyledText = styled<{}, 'div'>('div')`
+export const StyledText = styled.div`
   font-family: Muli, sans-serif;
   font-size: 14px;
   line-height: 1.29;
@@ -12,7 +12,7 @@ export const StyledText = styled<{}, 'div'>('div')`
   color: #686978;
 `
 
-export const StyledRemove = styled<{}, 'button'>('button')`
+export const StyledRemove = styled.button`
   margin: 0 8px;
   background: none;
   border: none;
@@ -23,7 +23,7 @@ export const StyledRemove = styled<{}, 'button'>('button')`
   padding: 0;
 `
 
-export const StyledTHOther = styled<{}, 'div'>('div')`
+export const StyledTHOther = styled.div`
   text-align: right;
 `
 
@@ -31,11 +31,11 @@ export const StyledTHLast = styled(StyledTHOther)`
   padding-right: 10px;
 `
 
-export const StyledToggleWrap = styled<{}, 'div'>('div')`
+export const StyledToggleWrap = styled.div`
   text-align: right;
 `
 
-export const StyledToggle = styled<{}, 'button'>('button')`
+export const StyledToggle = styled.button`
   font-family: Poppins, sans-serif;
   font-size: 13px;
   color: #4c54d2;
@@ -46,11 +46,11 @@ export const StyledToggle = styled<{}, 'button'>('button')`
   cursor: pointer;
 `
 
-export const StyledLink = styled<{}, 'a'>('a')`
+export const StyledLink = styled.a`
   text-decoration: none;
 `
 
-export const StyledRestoreSites = styled<{}, 'div'>('div')`
+export const StyledRestoreSites = styled.div`
   padding-top: 15px;
   margin-bottom: -20px;
 `

--- a/src/features/rewards/tableDonation/style.ts
+++ b/src/features/rewards/tableDonation/style.ts
@@ -4,7 +4,7 @@
 
 import styled from 'styled-components'
 
-export const StyledRemove = styled<{}, 'button'>('button')`
+export const StyledRemove = styled.button`
   font-family: Muli, sans-serif;
   font-size: 14px;
   line-height: 0;
@@ -17,7 +17,7 @@ export const StyledRemove = styled<{}, 'button'>('button')`
   display: inline-block;
 `
 
-export const StyledRemoveIcon = styled<{}, 'span'>('span')`
+export const StyledRemoveIcon = styled.span`
   vertical-align: middle;
   color: #9E9FAB;
   width: 12px;
@@ -26,7 +26,7 @@ export const StyledRemoveIcon = styled<{}, 'span'>('span')`
   margin-right: 4px;
 `
 
-export const StyledType = styled<{}, 'div'>('div')`
+export const StyledType = styled.div`
   font-family: Muli, sans-serif;
   font-size: 14px;
   font-weight: 600;
@@ -34,7 +34,7 @@ export const StyledType = styled<{}, 'div'>('div')`
   color: #686978;
 `
 
-export const StyledDate = styled<{}, 'div'>('div')`
+export const StyledDate = styled.div`
   font-family: Muli, sans-serif;
   font-size: 14px;
   line-height: 1;
@@ -42,7 +42,7 @@ export const StyledDate = styled<{}, 'div'>('div')`
   color: #b8b9c4;
 `
 
-export const StyledToggle = styled<{}, 'button'>('button')`
+export const StyledToggle = styled.button`
   font-family: Poppins, sans-serif;
   font-size: 13px;
   color: #4c54d2;
@@ -53,10 +53,10 @@ export const StyledToggle = styled<{}, 'button'>('button')`
   cursor: pointer;
 `
 
-export const StyledToggleWrap = styled<{}, 'div'>('div')`
+export const StyledToggleWrap = styled.div`
   text-align: right;
 `
 
-export const StyledLink = styled<{}, 'a'>('a')`
+export const StyledLink = styled.a`
   text-decoration: none;
 `

--- a/src/features/rewards/tableTransactions/style.ts
+++ b/src/features/rewards/tableTransactions/style.ts
@@ -25,16 +25,16 @@ interface StyleProps {
   type: TransactionType
 }
 
-export const StyledTHLast = styled<{}, 'div'>('div')`
+export const StyledTHLast = styled.div`
   text-align: right;
   padding-right: 14px;
 `
 
-export const StyledProvider = styled<{}, 'span'>('span')`
+export const StyledProvider = styled.span`
   color: #9e9fab;
 `
 
-export const StyledType = styled<StyleProps, 'div'>('div')`
+export const StyledType = styled.div<StyleProps>`
   ${getColor};
   color: var(--tableTransactions-type-color);
 `

--- a/src/features/rewards/tip/style.ts
+++ b/src/features/rewards/tip/style.ts
@@ -4,7 +4,7 @@
 
 import styled from 'styled-components'
 
-export const StyledWrapper = styled<{}, 'div'>('div')`
+export const StyledWrapper = styled.div`
   border-radius: 8px;
   background-image: linear-gradient(148deg, #2825a7, #5465e8), linear-gradient(#696fdc, #696fdc);
   width: 214px;
@@ -14,7 +14,7 @@ export const StyledWrapper = styled<{}, 'div'>('div')`
   font-family: Poppins, sans-serif;
 `
 
-export const StyledTitle = styled<{}, 'div'>('div')`
+export const StyledTitle = styled.div`
   font-size: 12px;
   line-height: 1.83;
   color: #fff;
@@ -22,21 +22,21 @@ export const StyledTitle = styled<{}, 'div'>('div')`
   padding-left: 23px;
 `
 
-export const StyledAllowToggle = styled<{}, 'span'>('span')`
+export const StyledAllowToggle = styled.span`
   display: inline-block;
   margin-left: 33px;
   vertical-align: middle;
   padding-top: 2px;
 `
 
-export const StyledAllowText = styled<{}, 'span'>('span')`
+export const StyledAllowText = styled.span`
   opacity: 0.65;
   font-size: 10px;
   line-height: 1.5;
   color: #fff;
 `
 
-export const StyledClose = styled<{}, 'button'>('button')`
+export const StyledClose = styled.button`
   position: absolute;
   top: 12px;
   right: 12px;
@@ -49,7 +49,7 @@ export const StyledClose = styled<{}, 'button'>('button')`
   z-index: 2;
 `
 
-export const StyledTipWrapper = styled<{}, 'div'>('div')`
+export const StyledTipWrapper = styled.div`
   display: flex;
   max-width: 160px;
   margin-bottom: 7px;

--- a/src/features/rewards/tipsMigrationAlert/style.ts
+++ b/src/features/rewards/tipsMigrationAlert/style.ts
@@ -9,7 +9,7 @@ interface StyleProps {
   modal?: boolean
 }
 
-export const StyledWrapper = styled<{}, 'div'>('div')`
+export const StyledWrapper = styled.div`
   width: 100%;
   display: flex;
   background: #E9F0FF;
@@ -19,13 +19,13 @@ export const StyledWrapper = styled<{}, 'div'>('div')`
   box-shadow: 0 1px 12px 0 rgba(99,105,110,0.18);
 `
 
-export const StyledAlertIcon = styled<{}, 'div'>('div')`
+export const StyledAlertIcon = styled.div`
   width: 57px;
   height: 57px;
   color: #15A4FA;
 `
 
-export const StyledInfo = styled<{}, 'div'>('div')`
+export const StyledInfo = styled.div`
   font-size: 14px;
   letter-spacing: 0;
   line-height: 18px;
@@ -34,26 +34,26 @@ export const StyledInfo = styled<{}, 'div'>('div')`
   max-width: 387px;
 `
 
-export const StyledMessage = styled<StyleProps, 'span'>('span')`
+export const StyledMessage = styled.span<StyleProps>`
   color: #000;
   margin-right: ${p => p.modal ? 5 : 3}px;
   font-weight: ${p => p.modal ? 500 : 400};
   font-size: ${p => p.modal ? '22px' : 'inherit'};
 `
 
-export const StyledMonthlyTips = styled<StyleProps, 'span'>('span')`
+export const StyledMonthlyTips = styled.span<StyleProps>`
   color: #696FDC;
   font-weight: ${p => p.modal ? 500 : 400};
   display: inline-block;
   font-size: ${p => p.modal ? '22px' : 'inherit'};
 `
 
-export const StyledReviewWrapper = styled<{}, 'div'>('div')`
+export const StyledReviewWrapper = styled.div`
   vertical-align: top;
   margin: 20px 0 0 7px;
 `
 
-export const StyledReviewList = styled<{}, 'span'>('span')`
+export const StyledReviewList = styled.span`
   color: #15A4FA;
   cursor: pointer;
   font-size: 14px;
@@ -62,49 +62,49 @@ export const StyledReviewList = styled<{}, 'span'>('span')`
   line-height: 18px;
 `
 
-export const StyledModalContent = styled<{}, 'div'>('div')`
+export const StyledModalContent = styled.div`
   display: block;
 `
 
-export const StyledTipsIcon = styled<{}, 'div'>('div')`
+export const StyledTipsIcon = styled.div`
   width: 20%;
   vertical-align: top;
   margin-top: -33px;
   display: inline-block;
 `
 
-export const StyledModalInfo = styled<{}, 'div'>('div')`
+export const StyledModalInfo = styled.div`
   width: 80%;
   padding-left: 20px;
   display: inline-block;
 `
 
-export const StyledListMessage = styled<{}, 'div'>('div')`
+export const StyledListMessage = styled.div`
   display: block;
   font-size: 16px;
   font-weight: 600;
   margin-top: 30px;
 `
 
-export const StyledList = styled<{}, 'ul'>('ul')`
+export const StyledList = styled.ul`
   display: block;
   font-size: 14px;
   font-weight: 300;
   padding-left: 20px;
 `
 
-export const StyledListItem = styled<{}, 'li'>('li')`
+export const StyledListItem = styled.li`
   display: block;
   display: list-item;
   line-height: 28px;
   list-style-type: disc;
 `
 
-export const StyledButton = styled<{}, 'div'>('div')`
+export const StyledButton = styled.div`
   width: 235px;
   margin: 40px auto 0 auto;
 `
 
-export const StyledButtonContainer = styled<{}, 'div'>('div')`
+export const StyledButtonContainer = styled.div`
   width: 100%;
 `

--- a/src/features/rewards/toggleTips/style.ts
+++ b/src/features/rewards/toggleTips/style.ts
@@ -4,14 +4,14 @@
 
 import styled from 'styled-components'
 
-export const StyledEnableTipsSection = styled<{}, 'section'>('section')`
+export const StyledEnableTipsSection = styled.section`
   background: #F5F5F9;
   display: block;
   width: 100%;
   padding: 10px 30px;
 ` as any
 
-export const StyledEnableTipsInner = styled<{}, 'div'>('div')`
+export const StyledEnableTipsInner = styled.div`
   color: #838391;
   font-size: 14px;
   font-weight: normal;
@@ -20,7 +20,7 @@ export const StyledEnableTipsInner = styled<{}, 'div'>('div')`
   position: relative;
 ` as any
 
-export const StyledEnableTips = styled<{}, 'span'>('span')`
+export const StyledEnableTips = styled.span`
   color: #4C54D2;
   font-size: 14px;
   font-weight: 500;
@@ -29,11 +29,11 @@ export const StyledEnableTips = styled<{}, 'span'>('span')`
   margin-right: 5px;
 ` as any
 
-export const StyledText = styled<{}, 'span'>('span')`
+export const StyledText = styled.span`
   margin-right: 5px;
 ` as any
 
-export const StyledProviderImg = styled<{}, 'span'>('span')`
+export const StyledProviderImg = styled.span`
   margin-right: 5px;
   vertical-align: middle;
   width: 20px;
@@ -42,12 +42,12 @@ export const StyledProviderImg = styled<{}, 'span'>('span')`
   display: inline-block;
 ` as any
 
-export const StyledProviderName = styled<{}, 'span'>('span')`
+export const StyledProviderName = styled.span`
   font-weight: 600;
   margin-right: 5px;
 ` as any
 
-export const StyledToggleOuter = styled<{}, 'div'>('div')`
+export const StyledToggleOuter = styled.div`
   display: inline-block;
   vertical-align: middle;
   margin-top: 3px;
@@ -56,12 +56,12 @@ export const StyledToggleOuter = styled<{}, 'div'>('div')`
   right: 0px;
 ` as any
 
-export const StyledToggleInner = styled<{}, 'div'>('div')`
+export const StyledToggleInner = styled.div`
   float: right;
   margin-top: 2px;
 ` as any
 
-export const StyledThumbsUpIcon = styled<{}, 'span'>('span')`
+export const StyledThumbsUpIcon = styled.span`
   width: 20px;
   height: 20px;
   display: inline-block;

--- a/src/features/rewards/tokens/style.ts
+++ b/src/features/rewards/tokens/style.ts
@@ -43,11 +43,11 @@ const getStyle = (p: Partial<Props>) => {
   `
 }
 
-export const StyledWrapper = styled<Partial<Props>, 'span'>('span')`
+export const StyledWrapper = styled.span<Partial<Props>>`
   ${getStyle}
 `
 
-export const StyledTokens = styled<{}, 'span'>('span')`
+export const StyledTokens = styled.span`
   font-family: Poppins, sans-serif;
   font-weight: 300;
   line-height: 1.4;
@@ -55,13 +55,13 @@ export const StyledTokens = styled<{}, 'span'>('span')`
   display: inline-block;
 `
 
-export const StyledTokenValue = styled<{}, 'span'>('span')`
+export const StyledTokenValue = styled.span`
   color: var(--tokens-value-color);
   font-size: var(--tokens-tokenNum-size);
   font-weight: 500;
 `
 
-export const StyledContent = styled<{}, 'span'>('span')`
+export const StyledContent = styled.span`
   color: #9E9FAB;
   font-size: var(--tokens-text-size);
   font-family: Muli, sans-serif;
@@ -70,7 +70,7 @@ export const StyledContent = styled<{}, 'span'>('span')`
   margin-left: 10px;
 `
 
-export const StyledTokenCurrency = styled<{}, 'span'>('span')`
+export const StyledTokenCurrency = styled.span`
   font-size: var(--tokens-token-size);
   font-weight: 300;
   display: inline-block;

--- a/src/features/rewards/tooltip/style.ts
+++ b/src/features/rewards/tooltip/style.ts
@@ -9,12 +9,12 @@ interface StyleProps {
   displayed?: boolean
 }
 
-export const StyledWrapper = styled<{}, 'div'>('div')`
+export const StyledWrapper = styled.div`
   display: inline-block;
   position: relative;
 `
 
-export const StyledTooltip = styled<StyleProps, 'div'>('div')`
+export const StyledTooltip = styled.div<StyleProps>`
   left: 50%;
   top: calc(100% + 10px);
   transform: translateX(-50%);
@@ -28,14 +28,14 @@ export const StyledTooltip = styled<StyleProps, 'div'>('div')`
   box-shadow: 1px 1px 5px 0 rgba(34, 35, 38, 0.43);
   display: ${p => p.displayed ? 'inline-block' : 'none'};
 `
-export const StyledTooltipText = styled<{}, 'div'>('div')`
+export const StyledTooltipText = styled.div`
   color: #FFFFFF;
   font-family: Muli, sans-serif;
   font-weight: 300;
   font-size: 14px;
 `
 
-export const StyledPointer = styled<{}, 'div'>('div')`
+export const StyledPointer = styled.div`
   width: 0;
   height: 0;
   border-style: solid;
@@ -46,6 +46,6 @@ export const StyledPointer = styled<{}, 'div'>('div')`
   border-color: transparent transparent #0C0D21 transparent;
 `
 
-export const StyledChildWrapper = styled<{}, 'div'>('div')`
+export const StyledChildWrapper = styled.div`
   cursor: pointer;
 `

--- a/src/features/rewards/walletEmpty/style.ts
+++ b/src/features/rewards/walletEmpty/style.ts
@@ -34,6 +34,6 @@ export const StyledContent = styled.div`
   }
 `
 
-export const StyledCenter = styled<{}, 'div'>('div')`
+export const StyledCenter = styled.div`
   text-align: center;
-` as any
+`

--- a/src/features/rewards/walletEmpty/style.ts
+++ b/src/features/rewards/walletEmpty/style.ts
@@ -4,13 +4,13 @@
 
 import styled from 'styled-components'
 
-export const StyledWrapper = styled<{}, 'div'>('div')`
+export const StyledWrapper = styled.div`
   padding-top: 32px;
   text-align: center;
   font-family: Poppins, sans-serif;
 `
 
-export const StyledTitle = styled<{}, 'div'>('div')`
+export const StyledTitle = styled.div`
   font-size: 22px;
   font-weight: 300;
   line-height: 1.05;
@@ -18,7 +18,7 @@ export const StyledTitle = styled<{}, 'div'>('div')`
   margin-top: 32px;
 `
 
-export const StyledContent = styled<{}, 'div'>('div')`
+export const StyledContent = styled.div`
   font-family: Muli, sans-serif;
   font-size: 14px;
   line-height: 1.57;

--- a/src/features/rewards/walletOff/style.ts
+++ b/src/features/rewards/walletOff/style.ts
@@ -4,13 +4,13 @@
 
 import styled from 'styled-components'
 
-export const StyledWrapper = styled<{}, 'div'>('div')`
+export const StyledWrapper = styled.div`
   padding: 32px 20px 46px;
   text-align: center;
   font-family: Poppins, sans-serif;
 `
 
-export const StyledTitle = styled<{}, 'div'>('div')`
+export const StyledTitle = styled.div`
   font-size: 16px;
   font-weight: 500;
   line-height: 1.75;
@@ -19,7 +19,7 @@ export const StyledTitle = styled<{}, 'div'>('div')`
   color: #5bc4fe;
 `
 
-export const StyledContent = styled<{}, 'div'>('div')`
+export const StyledContent = styled.div`
   font-family: Muli, sans-serif;
   font-size: 16px;
   line-height: 1.75;

--- a/src/features/rewards/walletPanel/style.ts
+++ b/src/features/rewards/walletPanel/style.ts
@@ -10,26 +10,26 @@ interface StyleProps {
   toggleTips?: boolean
 }
 
-export const StyledWrapper = styled<{}, 'div'>('div')`
+export const StyledWrapper = styled.div`
   display: block;
 ` as any
 
-export const StyledProfileWrapper = styled<{}, 'div'>('div')`
+export const StyledProfileWrapper = styled.div`
   margin-bottom: 15px;
 ` as any
 
-export const StyledContainer = styled<{}, 'div'>('div')`
+export const StyledContainer = styled.div`
   padding: 25px 30px 25px 30px;
 ` as any
 
-export const StyledAttentionScore = styled<{}, 'span'>('span')`
+export const StyledAttentionScore = styled.span`
   margin-left: 30px;
   font-weight: 500;
   color: #4B4C5C;
   font-size: 14px;
 ` as any
 
-export const StyledAttentionScoreTitle = styled<{}, 'span'>('span')`
+export const StyledAttentionScoreTitle = styled.span`
   font-weight: 400;
   color: #4B4C5C;
   font-size: 14px;
@@ -37,17 +37,17 @@ export const StyledAttentionScoreTitle = styled<{}, 'span'>('span')`
   margin: 0 0 0 2px;
 ` as any
 
-export const StyledScoreWrapper = styled<{}, 'section'>('section')`
+export const StyledScoreWrapper = styled.section`
   padding: 0 0px 6px;
 ` as any
 
-export const StyledControlsWrapper = styled<{}, 'section'>('section')`
+export const StyledControlsWrapper = styled.section`
   padding: 5px 0px;
   border-top: 1px solid #DBDFE3;
   border-bottom: 1px solid #DBDFE3;
 ` as any
 
-export const StyledDonateText = styled<{}, 'span'>('span')`
+export const StyledDonateText = styled.span`
   display: inline-block;
   font-size: 14px;
   font-weight: normal;
@@ -57,35 +57,35 @@ export const StyledDonateText = styled<{}, 'span'>('span')`
   color: ${p => p.theme.color.subtleInteracting};
 ` as any
 
-export const StyledDonateWrapper = styled<{}, 'div'>('div')`
+export const StyledDonateWrapper = styled.div`
   text-align: center;
   padding: 15px 0 0;
   margin: 0 auto;
 ` as any
 
-export const StyledToggleWrapper = styled<{}, 'div'>('div')`
+export const StyledToggleWrapper = styled.div`
   margin-top: 6px;
 ` as any
 
-export const StyledSelectWrapper = styled<{}, 'div'>('div')`
+export const StyledSelectWrapper = styled.div`
   width: 80px;
   margin: 2px 0px 0px;
 ` as any
 
-export const StyledGrid = styled<{}, 'div'>('div')`
+export const StyledGrid = styled.div`
   display: flex;
   flex-direction: row;
 `
 
-export const StyledColumn = styled<StyleProps, 'div'>('div')`
+export const StyledColumn = styled.div<StyleProps>`
   flex: ${p => p.size} 0 0;
 `
 
-export const StyleToggleTips = styled<StyleProps, 'div'>('div')`
+export const StyleToggleTips = styled.div<StyleProps>`
   display: ${p => p.toggleTips ? 'flex' : 'none'};
 `
 
-export const StyledNoticeWrapper = styled<StyleProps, 'div'>('div')`
+export const StyledNoticeWrapper = styled.div<StyleProps>`
   background: rgba(0, 0, 0, 0.04);
   color: #676283;
   font-size: 12px;
@@ -98,7 +98,7 @@ export const StyledNoticeWrapper = styled<StyleProps, 'div'>('div')`
   margin: 11px 0 10px;
 `
 
-export const StyledNoticeLink = styled<StyleProps, 'a'>('a')`
+export const StyledNoticeLink = styled.a<StyleProps>`
   color: ${palette.blue400};
   font-weight: bold;
   text-decoration: none;

--- a/src/features/rewards/walletSummary/style.ts
+++ b/src/features/rewards/walletSummary/style.ts
@@ -13,17 +13,17 @@ const getGradientRule = (gradient: string) => {
   return `linear-gradient(-180deg, rgba(${gradient},1) 0%, rgba(255,255,255,1) 60%)`
 }
 
-export const StyledWrapper = styled<StyleProps, 'div'>('div')`
+export const StyledWrapper = styled.div<StyleProps>`
   height: 100%;
   padding: ${p => p.compact ? '0px 7px 0px' : '0px'};
   background: ${p => p.compact ? getGradientRule('233, 235, 255') : 'inherit'};
 `
 
-export const StyledInner = styled<StyleProps, 'div'>('div')`
+export const StyledInner = styled.div<StyleProps>`
   padding: 25px 14px 14px;
   font-family: Poppins, sans-serif;
 `
-export const StyledSummary = styled<{}, 'div'>('div')`
+export const StyledSummary = styled.div`
   font-size: 14px;
   font-weight: 600;
   line-height: 1.57;
@@ -32,7 +32,7 @@ export const StyledSummary = styled<{}, 'div'>('div')`
   text-transform: uppercase;
 `
 
-export const StyledTitle = styled<{}, 'div'>('div')`
+export const StyledTitle = styled.div`
   font-size: 22px;
   font-weight: 300;
   line-height: 0.79;
@@ -42,7 +42,7 @@ export const StyledTitle = styled<{}, 'div'>('div')`
   text-transform: uppercase;
 `
 
-export const StyledActivity = styled<{}, 'button'>('button')`
+export const StyledActivity = styled.button`
   font-size: 12px;
   color: #686978;
   margin-top: 26px;
@@ -54,7 +54,7 @@ export const StyledActivity = styled<{}, 'button'>('button')`
   cursor: pointer;
 `
 
-export const StyledActivityIcon = styled<{}, 'span'>('span')`
+export const StyledActivityIcon = styled.span`
   vertical-align: middle;
   margin-right: 11px;
   width: 22px;
@@ -63,19 +63,19 @@ export const StyledActivityIcon = styled<{}, 'span'>('span')`
   display: inline-block;
 `
 
-export const StyledNoActivityWrapper = styled<{}, 'div'>('div')`
+export const StyledNoActivityWrapper = styled.div`
   width: 100%;
   margin-top: 80px;
   text-align: center;
 `
 
-export const StyledNoActivity = styled<{}, 'span'>('span')`
+export const StyledNoActivity = styled.span`
   font-weight: 400;
   color: #B8B9C4;
   font-size: 18px;
 `
 
-export const StyledReservedWrapper = styled<{}, 'div'>('div')`
+export const StyledReservedWrapper = styled.div`
   background: rgba(0, 0, 0, 0.04);
   color: #676283;
   font-size: 12px;
@@ -88,7 +88,7 @@ export const StyledReservedWrapper = styled<{}, 'div'>('div')`
   margin: 20px 0 10px;
 `
 
-export const StyledReservedLink = styled<StyleProps, 'a'>('a')`
+export const StyledReservedLink = styled.a<StyleProps>`
   color: ${palette.blue400};
   font-weight: bold;
   text-decoration: none;

--- a/src/features/rewards/walletSummarySlider/style.ts
+++ b/src/features/rewards/walletSummarySlider/style.ts
@@ -9,20 +9,20 @@ interface StyleProps {
   size?: string
 }
 
-export const StyledWrapper = styled<{}, 'div'>('div')`
+export const StyledWrapper = styled.div`
   display: block;
   width: 100%;
   height: 100%;
   position: relative;
 ` as any
 
-export const StyledTransitionWrapper = styled<StyleProps, 'div'>('div')`
+export const StyledTransitionWrapper = styled.div<StyleProps>`
   height: ${p => p.show ? '100%' : '0'};
   opacity: ${p => p.show ? '1' : '0'};
   overflow: ${p => p.show ? 'unset' : 'hidden'};
 ` as any
 
-export const StyledToggleWrapper = styled<StyleProps, 'div'>('div')`
+export const StyledToggleWrapper = styled.div<StyleProps>`
   width: 100%;
   display: block;
   max-height: 56px;
@@ -33,7 +33,7 @@ export const StyledToggleWrapper = styled<StyleProps, 'div'>('div')`
   background: ${p => p.show ? '#E9EBFF' : 'inherit'};
 ` as any
 
-export const StyledSummaryText = styled<{}, 'span'>('span')`
+export const StyledSummaryText = styled.span`
   color: #A1A8F2;
   font-size: 14px;
   font-weight: 600;
@@ -42,19 +42,19 @@ export const StyledSummaryText = styled<{}, 'span'>('span')`
   line-height: 22px;
 ` as any
 
-export const StyledArrowIcon = styled<StyleProps, 'span'>('span')`
+export const StyledArrowIcon = styled.span<StyleProps>`
   width: 24px;
   height: 24px;
   display: flex;
   color: #696FDC;
 ` as any
 
-export const StyledGrid = styled<{}, 'div'>('div')`
+export const StyledGrid = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
 `
 
-export const StyledColumn = styled<StyleProps, 'div'>('div')`
+export const StyledColumn = styled.div<StyleProps>`
   display: flex;
 `

--- a/src/features/rewards/walletWrapper/style.ts
+++ b/src/features/rewards/walletWrapper/style.ts
@@ -32,7 +32,7 @@ const wrapperBackgroundRules = (notification: Notification | undefined) => {
   return 'linear-gradient(-180deg, rgba(255,255,255,1) 0%, rgba(228,242,255,1) 40%)'
 }
 
-export const StyledWrapper = styled<StyledProps, 'div'>('div')`
+export const StyledWrapper = styled.div<StyledProps>`
   overflow: hidden;
   box-shadow: 0 1px 12px 0 rgba(99,105,110,0.18);
   font-family: Poppins, sans-serif;
@@ -46,12 +46,12 @@ export const StyledWrapper = styled<StyledProps, 'div'>('div')`
   margin: 0 auto;
 `
 
-export const StyledHeader = styled<{}, 'div'>('div')`
+export const StyledHeader = styled.div`
   padding: 16px 21px 0 19px;
   position: relative;
 `
 
-export const StyledTitle = styled<{}, 'div'>('div')`
+export const StyledTitle = styled.div`
   font-size: 16px;
   font-weight: 500;
   line-height: 1.38;
@@ -59,16 +59,16 @@ export const StyledTitle = styled<{}, 'div'>('div')`
   color: rgba(255, 255, 255, 0.65);
 `
 
-export const StyledBalance = styled<{}, 'div'>('div')`
+export const StyledBalance = styled.div`
   text-align: center;
 `
 
-export const StyleGrantButton = styled<{}, 'div'>('div')`
+export const StyleGrantButton = styled.div`
   display: flex;
   justify-content: center;
 `
 
-export const StyledBalanceTokens = styled<{}, 'div'>('div')`
+export const StyledBalanceTokens = styled.div`
   font-size: 36px;
   line-height: 0.61;
   letter-spacing: -0.4px;
@@ -77,7 +77,7 @@ export const StyledBalanceTokens = styled<{}, 'div'>('div')`
   font-weight: 300;
 `
 
-export const StyledContent = styled<StyledProps, 'div'>('div')`
+export const StyledContent = styled.div<StyledProps>`
   padding: ${p => p.contentPadding ? '11px 25px 19px' : '0px'};
   position: relative;
   background: #f9fbfc;
@@ -85,7 +85,7 @@ export const StyledContent = styled<StyledProps, 'div'>('div')`
   height: 381px;
 `
 
-export const StyledAction = styled<{}, 'button'>('button')`
+export const StyledAction = styled.button`
   display: flex;
   background: none;
   padding: 4px;
@@ -95,7 +95,7 @@ export const StyledAction = styled<{}, 'button'>('button')`
   color: #A1A8F2;
 `
 
-export const StyledActionIcon = styled<{}, 'div'>('div')`
+export const StyledActionIcon = styled.div`
   display: inline-block;
   width: 24px;
   height: 24px;
@@ -103,13 +103,13 @@ export const StyledActionIcon = styled<{}, 'div'>('div')`
   vertical-align: text-bottom;
 `
 
-export const StyledActionText = styled<{}, 'div'>('div')`
+export const StyledActionText = styled.div`
   color: #fff;
   font-size: 14px;
   opacity: 0.65;
 `
 
-export const StyledCopy = styled<StyledProps, 'div'>('div')`
+export const StyledCopy = styled.div<StyledProps>`
   font-size: 12px;
   color: #838391;
   padding: 19px 15px;
@@ -117,7 +117,7 @@ export const StyledCopy = styled<StyledProps, 'div'>('div')`
   text-align: center;
 `
 
-export const StyledCopyImage = styled<{}, 'span'>('span')`
+export const StyledCopyImage = styled.span`
   vertical-align: middle;
   display: inline-block;
   color: #838391;
@@ -125,7 +125,7 @@ export const StyledCopyImage = styled<{}, 'span'>('span')`
   height: 27px;
 `
 
-export const StyledIconAction = styled<{}, 'button'>('button')`
+export const StyledIconAction = styled.button`
   position: absolute;
   top: 15px;
   right: 21px;
@@ -138,7 +138,7 @@ export const StyledIconAction = styled<{}, 'button'>('button')`
   height: 24px;
 `
 
-export const StyledBalanceConverted = styled<{}, 'div'>('div')`
+export const StyledBalanceConverted = styled.div`
   font-family: Muli, sans-serif;
   font-size: 12px;
   line-height: 1.17;
@@ -148,11 +148,11 @@ export const StyledBalanceConverted = styled<{}, 'div'>('div')`
   font-weight: 300;
 `
 
-export const StyledGrantWrapper = styled<{}, 'div'>('div')`
+export const StyledGrantWrapper = styled.div`
   margin-top: 13px;
 `
 
-export const StyledGrant = styled<{}, 'div'>('div')`
+export const StyledGrant = styled.div`
   font-family: Muli, sans-serif;
   font-size: 12px;
   color: rgba(255, 255, 255, 0.60);
@@ -174,7 +174,7 @@ export const StyledGrant = styled<{}, 'div'>('div')`
   }
 `
 
-export const StyledActionWrapper = styled<{}, 'div'>('div')`
+export const StyledActionWrapper = styled.div`
   text-align: center;
   font-size: 12px;
   color: #fff;
@@ -184,7 +184,7 @@ export const StyledActionWrapper = styled<{}, 'div'>('div')`
   padding-bottom: 3px;
 `
 
-export const StyledBalanceCurrency = styled<{}, 'span'>('span')`
+export const StyledBalanceCurrency = styled.span`
   text-transform: uppercase;
   opacity: 0.66;
   font-family: Muli, sans-serif;
@@ -193,7 +193,7 @@ export const StyledBalanceCurrency = styled<{}, 'span'>('span')`
   color: #fff;
 `
 
-export const StyledCurve = styled<StyledProps, 'div'>('div')`
+export const StyledCurve = styled.div<StyledProps>`
   padding: 10px 0;
   position: relative;
   overflow: hidden;
@@ -212,7 +212,7 @@ export const StyledCurve = styled<StyledProps, 'div'>('div')`
   }
 `
 
-export const StyledAlertWrapper = styled<{}, 'div'>('div')`
+export const StyledAlertWrapper = styled.div`
   display: flex;
   align-items: stretch;
   position: absolute;
@@ -223,7 +223,7 @@ export const StyledAlertWrapper = styled<{}, 'div'>('div')`
   width: 100%;
 `
 
-export const StyledAlertClose = styled<{}, 'button'>('button')`
+export const StyledAlertClose = styled.button`
   position: absolute;
   background: none;
   border: none;
@@ -236,7 +236,7 @@ export const StyledAlertClose = styled<{}, 'button'>('button')`
   color: #B8B9C4;
 `
 
-export const StyledBAT = styled<{}, 'div'>('div')`
+export const StyledBAT = styled.div`
   text-align: center;
   max-width: 300px;
   margin: 20px auto 0;
@@ -251,13 +251,13 @@ export const StyledBAT = styled<{}, 'div'>('div')`
   }
 `
 
-export const StyledNotificationIcon = styled<StyledProps, 'img'>('img')`
+export const StyledNotificationIcon = styled.img<StyledProps>`
   height: 48px;
   width: 48px;
   margin: 8px 0px 12px;
 `
 
-export const StyledNotificationCloseIcon = styled<StyledProps, 'div'>('div')`
+export const StyledNotificationCloseIcon = styled.div<StyledProps>`
   height: 20px;
   width: 20px;
   position: absolute;
@@ -267,32 +267,32 @@ export const StyledNotificationCloseIcon = styled<StyledProps, 'div'>('div')`
   cursor: pointer;
 `
 
-export const StyledNotificationContent = styled<StyledProps, 'div'>('div')`
+export const StyledNotificationContent = styled.div<StyledProps>`
   display: block;
   text-align: center;
 `
 
-export const StyledNotificationMessage = styled<StyledProps, 'div'>('div')`
+export const StyledNotificationMessage = styled.div<StyledProps>`
   max-width: 285px;
   color: #4B4C5C;
   padding-bottom: 5px;
   margin: 0 auto;
 `
 
-export const StyledTypeText = styled<StyledProps, 'span'>('span')`
+export const StyledTypeText = styled.span<StyledProps>`
   font-weight: 500;
   margin-right: 5px;
   display: inline-block;
 `
 
-export const StyledMessageText = styled<StyledProps, 'span'>('span')`
+export const StyledMessageText = styled.span<StyledProps>`
   line-height: 20px;
   font-weight: 400;
   margin: 0px 5px;
   font-family: Muli, sans-serif;
 `
 
-export const StyledDateText = styled<StyledProps, 'span'>('span')`
+export const StyledDateText = styled.span<StyledProps>`
   font-weight: 400;
   margin-left: 5px;
   display: inline-block;
@@ -300,7 +300,7 @@ export const StyledDateText = styled<StyledProps, 'span'>('span')`
   font-family: Muli, sans-serif;
 `
 
-export const StyledButtonWrapper = styled<StyledProps, 'div'>('div')`
+export const StyledButtonWrapper = styled.div<StyledProps>`
   margin: 12px 0 15px;
   display: flex;
   justify-content: center;
@@ -311,6 +311,6 @@ export const StyledButton = styled(Button as ComponentType<ButtonProps>)`
   padding-right: 27px;
 `
 
-export const StyledPipe = styled<StyledProps, 'span'>('span')`
+export const StyledPipe = styled.span<StyledProps>`
   font-weight: 300;
 `

--- a/src/features/rewards/welcomePage/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/welcomePage/__snapshots__/spec.tsx.snap
@@ -12,7 +12,7 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
   border-bottom-right-radius: 150% 120px;
 }
 
-.c33 {
+.c29 {
   height: 290px;
   border-radius: 4px;
   text-align: center;
@@ -24,7 +24,7 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
   font-family: Poppins,sans-serif;
 }
 
-.c36 {
+.c32 {
   color: #222326;
   font-size: 18px;
   font-weight: 500;
@@ -35,7 +35,7 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
   letter-spacing: 0.16px;
 }
 
-.c37 {
+.c33 {
   color: #686978;
   font-size: 16px;
   line-height: 22px;
@@ -48,7 +48,7 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
   font-weight: 400;
 }
 
-.c34 {
+.c30 {
   box-sizing: border-box;
   display: block;
   max-width: 100%;
@@ -56,7 +56,7 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
   height: 80px;
 }
 
-.c31 {
+.c27 {
   display: grid;
   grid-gap: 0px;
   grid-template-columns: 1fr 1fr 1fr;
@@ -70,23 +70,20 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
   justify-content: center;
 }
 
-.c32 {
+.c28 {
   padding: 0 10px;
 }
 
-.c22 {
+.c19 {
   width: 100%;
   height: 100%;
   fill: currentColor;
-}
-
-.c21 {
   -webkit-transform: rotate(-90deg);
   -ms-transform: rotate(-90deg);
   transform: rotate(-90deg);
 }
 
-.c38 {
+.c34 {
   width: 100%;
   height: 100%;
   fill: currentColor;
@@ -98,55 +95,46 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
   fill: currentColor;
 }
 
+.c31 {
+  width: 100%;
+  height: 100%;
+  fill: currentColor;
+}
+
 .c35 {
   width: 100%;
   height: 100%;
   fill: currentColor;
 }
 
-.c39 {
-  width: 100%;
-  height: 100%;
-  fill: currentColor;
-}
-
-.c10 {
+.c9 {
   box-sizing: border-box;
   font-family: Poppins,sans-serif;
   font-weight: 400;
   -webkit-font-smoothing: antialiased;
   margin: 0;
-}
-
-.c9 {
   font-size: 40px;
 }
 
-.c28 {
+.c24 {
   box-sizing: border-box;
   font-family: Poppins,sans-serif;
   font-weight: 400;
   -webkit-font-smoothing: antialiased;
   margin: 0;
-}
-
-.c27 {
   font-size: 32px;
 }
 
-.c14 {
+.c12 {
   box-sizing: border-box;
   font-family: Poppins,sans-serif;
   font-weight: 400;
   -webkit-font-smoothing: antialiased;
   margin: 0;
-}
-
-.c13 {
   font-size: 24px;
 }
 
-.c17 {
+.c15 {
   width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
@@ -167,15 +155,15 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
   border: 1px solid rgba(255,255,255,0.35);
 }
 
-.c17:hover {
+.c15:hover {
   background: rgba(0,0,0,0.05);
 }
 
-.c17:focus {
+.c15:focus {
   outline: 0;
 }
 
-.c44 {
+.c40 {
   width: 100%;
   display: -webkit-box;
   display: -webkit-flex;
@@ -195,11 +183,11 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
   background: #ff7654;
 }
 
-.c44:focus {
+.c40:focus {
   outline: 0;
 }
 
-.c18 {
+.c16 {
   font-family: Poppins,sans-serif;
   font-weight: 600;
   text-transform: uppercase;
@@ -223,25 +211,25 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
   padding: 40px 0;
 }
 
-.c16 {
+.c14 {
   margin: 40px auto;
   max-width: 303px;
 }
 
-.c43 {
+.c39 {
   max-width: 303px;
   margin: 0 auto;
 }
 
-.c41 {
+.c37 {
   text-align: center;
 }
 
-.c23 {
+.c20 {
   padding: 15px 0 0;
 }
 
-.c24 {
+.c21 {
   margin: 0 auto;
   max-width: 692px;
   padding: 67px 0 20px;
@@ -251,12 +239,12 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
   display: block;
 }
 
-.c30 {
+.c26 {
   margin: 22px auto 0;
   max-width: 900px;
 }
 
-.c40 {
+.c36 {
   margin: 0 auto;
   padding: 64px 0 79px;
   max-width: 500px;
@@ -279,14 +267,14 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
   margin: 17px 0 4px;
 }
 
-.c42 {
+.c38 {
   color: #5C58C2;
   font-weight: normal;
   line-height: 28px;
   margin: 18px 0 30px;
 }
 
-.c26 {
+.c23 {
   color: #222326;
   font-weight: normal;
   text-align: left;
@@ -295,14 +283,14 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
   margin: 0;
 }
 
-.c12 {
+.c11 {
   color: #5BC4FE;
   font-weight: 500;
   text-align: center;
   margin: 18px 0 7px;
 }
 
-.c11 {
+.c10 {
   display: inline-block;
   vertical-align: text-top;
   margin-top: -25px;
@@ -312,7 +300,7 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
   opacity: 0.7;
 }
 
-.c15 {
+.c13 {
   font-size: 16px;
   max-width: 375px;
   margin: 0 auto;
@@ -320,7 +308,7 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
   color: #FFF;
 }
 
-.c19 {
+.c17 {
   font-size: 16px;
   margin: 0 0 5px;
   line-height: 28px;
@@ -328,7 +316,7 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
   opacity: 0.5;
 }
 
-.c29 {
+.c25 {
   font-size: 16px;
   line-height: 28px;
   color: #686978;
@@ -342,7 +330,7 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
   font-family: Muli,sans-serif;
 }
 
-.c20 {
+.c18 {
   padding: 0;
   border: none;
   background: none;
@@ -353,7 +341,7 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
   outline: none;
 }
 
-.c20:focus {
+.c18:focus {
   outline: 0;
 }
 
@@ -364,21 +352,21 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
 }
 
 @media (max-width:640px) {
-  .c31 {
+  .c27 {
     grid-gap: 20px;
     grid-template-columns: 1fr;
   }
 }
 
 @media (max-width:410px) {
-  .c16 {
+  .c14 {
     margin: 40px 20px;
     max-width: unset;
   }
 }
 
 @media (max-width:767px) {
-  .c24 {
+  .c21 {
     max-width: none;
     width: 100%;
     padding-top: 30px;
@@ -386,7 +374,7 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
 }
 
 @media (max-width:767px) {
-  .c25 {
+  .c22 {
     margin: 0 auto;
     width: 80%;
   }
@@ -411,7 +399,7 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
 }
 
 @media (max-width:360px) {
-  .c12 {
+  .c11 {
     font-size: 22px;
   }
 }
@@ -477,38 +465,38 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
               className="c7"
             >
               <h2
-                className="c8 c9 c10"
+                className="c8 c9"
               >
                 MISSING: braveRewardsTitle
               </h2>
               <span
-                className="c11"
+                className="c10"
               >
                 TM
               </span>
               <h4
-                className="c12 c13 c14"
+                className="c11 c12"
               >
                 MISSING: braveRewardsSubTitle
               </h4>
               <p
-                className="c15"
+                className="c13"
               >
                 MISSING: braveRewardsDesc
               </p>
             </div>
           </div>
           <section
-            className="c16"
+            className="c14"
           >
             <button
-              className="c17"
+              className="c15"
               data-test-id="optInAction"
               onClick={[Function]}
               type="opt-in"
             >
               <span
-                className="c18"
+                className="c16"
               >
                 MISSING: braveRewardsOptInText
               </span>
@@ -518,17 +506,17 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
             className="c3"
           >
             <p
-              className="c19"
+              className="c17"
             >
               MISSING: braveRewardsTeaser
             </p>
             <button
-              className="c20"
+              className="c18"
               onClick={[Function]}
             >
               <svg
                 aria-hidden="true"
-                className="c21 c22"
+                className="c19"
                 focusable="false"
                 viewBox="0 0 32 32"
               >
@@ -541,29 +529,29 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
         </div>
       </div>
       <section
-        className="c23"
+        className="c20"
       >
         <section
-          className="c23"
+          className="c20"
         >
           <div
-            className="c24"
+            className="c21"
           >
             <section
-              className="c25"
+              className="c22"
             >
               <h3
-                className="c26 c27 c28"
+                className="c23 c24"
               >
                 MISSING: whyBraveRewards
               </h3>
               <p
-                className="c29"
+                className="c25"
               >
                 MISSING: whyBraveRewardsDesc1
               </p>
               <p
-                className="c29"
+                className="c25"
               >
                 MISSING: whyBraveRewardsDesc2
               </p>
@@ -571,26 +559,26 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
           </div>
         </section>
         <section
-          className="c30"
+          className="c26"
         >
           <section
             id="rewards-info"
           >
             <div
-              className="c31"
+              className="c27"
             >
               <div
-                className="c32"
+                className="c28"
               >
                 <div
-                  className="c33"
+                  className="c29"
                 >
                   <figure
-                    className="c34"
+                    className="c30"
                   >
                     <svg
                       aria-hidden="true"
-                      className="c35"
+                      className="c31"
                       focusable="false"
                       viewBox="0 0 32 32"
                     >
@@ -609,29 +597,29 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
                     </svg>
                   </figure>
                   <strong
-                    className="c36"
+                    className="c32"
                   >
                     MISSING: turnOnRewardsTitle
                   </strong>
                   <p
-                    className="c37"
+                    className="c33"
                   >
                     MISSING: turnOnRewardsDesc
                   </p>
                 </div>
               </div>
               <div
-                className="c32"
+                className="c28"
               >
                 <div
-                  className="c33"
+                  className="c29"
                 >
                   <figure
-                    className="c34"
+                    className="c30"
                   >
                     <svg
                       aria-hidden="true"
-                      className="c38"
+                      className="c34"
                       focusable="false"
                       viewBox="0 0 32 32"
                     >
@@ -650,29 +638,29 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
                     </svg>
                   </figure>
                   <strong
-                    className="c36"
+                    className="c32"
                   >
                     MISSING: braveAdsTitle
                   </strong>
                   <p
-                    className="c37"
+                    className="c33"
                   >
                     MISSING: braveAdsDesc
                   </p>
                 </div>
               </div>
               <div
-                className="c32"
+                className="c28"
               >
                 <div
-                  className="c33"
+                  className="c29"
                 >
                   <figure
-                    className="c34"
+                    className="c30"
                   >
                     <svg
                       aria-hidden="true"
-                      className="c39"
+                      className="c35"
                       focusable="false"
                       viewBox="0 0 32 32"
                     >
@@ -699,12 +687,12 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
                     </svg>
                   </figure>
                   <strong
-                    className="c36"
+                    className="c32"
                   >
                     MISSING: braveContributeTitle
                   </strong>
                   <p
-                    className="c37"
+                    className="c33"
                   >
                     MISSING: braveContributeDesc
                   </p>
@@ -714,26 +702,26 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
           </section>
         </section>
         <section
-          className="c40"
+          className="c36"
         >
           <section
-            className="c41"
+            className="c37"
           >
             <h4
-              className="c42 c13 c14"
+              className="c38 c12"
             >
               MISSING: readyToTakePart
             </h4>
             <section
-              className="c43"
+              className="c39"
             >
               <button
-                className="c44"
+                className="c40"
                 onClick={[Function]}
                 type="cta-opt-in"
               >
                 <span
-                  className="c18"
+                  className="c16"
                 >
                   MISSING: readyToTakePartOptInText
                 </span>

--- a/src/features/rewards/welcomePage/index.tsx
+++ b/src/features/rewards/welcomePage/index.tsx
@@ -232,7 +232,7 @@ class WelcomePage extends React.PureComponent<Props, {}> {
             {this.hero()}
           </StyledSection>
           <StyledCenterSection>
-            <StyledCenterSection innerRef={this.refSet}>
+            <StyledCenterSection ref={this.refSet}>
               {this.centerTextContent}
             </StyledCenterSection>
             <StyledInfoContent>

--- a/src/features/rewards/welcomePage/style.ts
+++ b/src/features/rewards/welcomePage/style.ts
@@ -6,7 +6,7 @@ import styled from 'styled-components'
 import Heading from '../../../components/text/heading'
 import centerBackgroundUrl from './assets/centerTextBackground.svg'
 
-export const StyledOptInSection = styled<{}, 'section'>('section')`
+export const StyledOptInSection = styled.section`
   margin: 40px auto;
   max-width: 303px;
 
@@ -16,20 +16,20 @@ export const StyledOptInSection = styled<{}, 'section'>('section')`
   }
 `
 
-export const StyledOptInSecond = styled<{}, 'section'>('section')`
+export const StyledOptInSecond = styled.section`
   max-width: 303px;
   margin: 0 auto;
 `
 
-export const StyledOptInInnerSection = styled<{}, 'section'>('section')`
+export const StyledOptInInnerSection = styled.section`
   text-align: center;
 `
 
-export const StyledCenterSection = styled<{}, 'section'>('section')`
+export const StyledCenterSection = styled.section`
   padding: 15px 0 0;
 `
 
-export const StyledCenterContent = styled<{}, 'div'>('div')`
+export const StyledCenterContent = styled.div`
   margin: 0 auto;
   max-width: 692px;
   padding: 67px 0 20px;
@@ -41,30 +41,30 @@ export const StyledCenterContent = styled<{}, 'div'>('div')`
   }
 `
 
-export const StyledSection = styled<{}, 'div'>('div')`
+export const StyledSection = styled.div`
   display: block;
 `
 
-export const StyledCenterInner = styled<{}, 'section'>('section')`
+export const StyledCenterInner = styled.section`
   @media (max-width: 767px) {
     margin: 0 auto;
     width: 80%;
   }
 `
 
-export const StyledInfoContent = styled<{}, 'section'>('section')`
+export const StyledInfoContent = styled.section`
   margin: 22px auto 0;
   max-width: 900px;
 `
 
-export const StyledTakeActionContent = styled<{}, 'section'>('section')`
+export const StyledTakeActionContent = styled.section`
   margin: 0 auto;
   padding: 64px 0 79px;
   max-width: 500px;
   display: block;
 `
 
-export const StyledBackground = styled<{}, 'div'>('div')`
+export const StyledBackground = styled.div`
   background: url(${centerBackgroundUrl}) no-repeat top;
 
   @media (max-width: 980px) {
@@ -72,7 +72,7 @@ export const StyledBackground = styled<{}, 'div'>('div')`
   }
 `
 
-export const StyledBatLogo = styled<{}, 'div'>('div')`
+export const StyledBatLogo = styled.div`
   margin: 5px auto 0;
   height: 152px;
 
@@ -119,7 +119,7 @@ export const StyledSubTitle = styled(Heading)`
   }
 `
 
-export const StyledTrademark = styled<{}, 'span'>('span')`
+export const StyledTrademark = styled.span`
   display: inline-block;
   vertical-align: text-top;
   margin-top: -25px;
@@ -129,7 +129,7 @@ export const StyledTrademark = styled<{}, 'span'>('span')`
   opacity: 0.7;
 `
 
-export const StyledRewardsParagraph = styled<{}, 'p'>('p')`
+export const StyledRewardsParagraph = styled.p`
   font-size: 16px;
   max-width: 375px;
   margin: 0 auto;
@@ -137,7 +137,7 @@ export const StyledRewardsParagraph = styled<{}, 'p'>('p')`
   color: #FFF;
 `
 
-export const StyledTeaserParagraph = styled<{}, 'p'>('p')`
+export const StyledTeaserParagraph = styled.p`
   font-size: 16px;
   margin: 0 0 5px;
   line-height: 28px;
@@ -145,7 +145,7 @@ export const StyledTeaserParagraph = styled<{}, 'p'>('p')`
   opacity: 0.5;
 `
 
-export const StyledCenterParagraph = styled<{}, 'p'>('p')`
+export const StyledCenterParagraph = styled.p`
   font-size: 16px;
   line-height: 28px;
   color: #686978;
@@ -156,7 +156,7 @@ export const StyledCenterParagraph = styled<{}, 'p'>('p')`
   font-family: Muli,sans-serif;
 `
 
-export const StyledAnchor = styled<{}, 'button'>('button')`
+export const StyledAnchor = styled.button`
   padding: 0;
   border: none;
   background: none;
@@ -171,12 +171,12 @@ export const StyledAnchor = styled<{}, 'button'>('button')`
   }
 `
 
-export const StyledHeroInfo = styled<{}, 'div'>('div')`
+export const StyledHeroInfo = styled.div`
   @media (max-width: 400px) {
     padding: 0 10px;
   }
 `
-export const StyledAlert = styled<{}, 'div'>('div')`
+export const StyledAlert = styled.div`
   margin-bottom: 30px;
   border: 1px solid #F43405;
   border-radius: 4px;
@@ -187,12 +187,12 @@ export const StyledAlert = styled<{}, 'div'>('div')`
   }
 `
 
-export const StyledAlertContent = styled<{}, 'div'>('div')`
+export const StyledAlertContent = styled.div`
   display: flex;
   width: 100%;
 `
 
-export const StyledAlertLeft = styled<{}, 'div'>('div')`
+export const StyledAlertLeft = styled.div`
   flex-basis: 70%;
   flex-grow: 1;
 `

--- a/src/features/shields/display.ts
+++ b/src/features/shields/display.ts
@@ -10,7 +10,7 @@ import { ComponentType } from 'react'
 /**
  * Header
  */
-export const MainToggleHeading = styled<{}, 'h1'>('h1')`
+export const MainToggleHeading = styled.h1`
   box-sizing: border-box;
   font-size: 16px;
   line-height: 20px;
@@ -19,7 +19,7 @@ export const MainToggleHeading = styled<{}, 'h1'>('h1')`
   margin: 0;
 `
 
-export const MainToggleText = styled<{}, 'p'>('p')`
+export const MainToggleText = styled.p`
   box-sizing: border-box;
   color: ${palette.grey600};
   font-size: 12px;
@@ -32,7 +32,7 @@ interface ToggleStateTextProps {
   status: 'enabled' | 'disabled'
 }
 
-export const ToggleStateText = styled<ToggleStateTextProps, 'span'>('span')`
+export const ToggleStateText = styled.span<ToggleStateTextProps>`
   box-sizing: border-box;
   color: ${p => p.status === 'enabled' ? palette.orange400 : palette.grey300};
   font-size: inherit;
@@ -41,14 +41,14 @@ export const ToggleStateText = styled<ToggleStateTextProps, 'span'>('span')`
   font-weight: 600;
 `
 
-export const Favicon = styled<{}, 'img'>('img')`
+export const Favicon = styled.img`
   box-sizing: border-box;
   display: block;
   max-width: 100%;
   width: 24px;
 `
 
-export const SiteInfoText = styled<{}, 'p'>('p')`
+export const SiteInfoText = styled.p`
   box-sizing: border-box;
   font-size: 22px;
   font-weight: 500;
@@ -57,7 +57,7 @@ export const SiteInfoText = styled<{}, 'p'>('p')`
   margin: 0;
 `
 
-export const TotalBlockedStatsNumber = styled<{}, 'h2'>('h2')`
+export const TotalBlockedStatsNumber = styled.h2`
   box-sizing: border-box;
   font-size: 38px;
   text-transform: uppercase;
@@ -67,7 +67,7 @@ export const TotalBlockedStatsNumber = styled<{}, 'h2'>('h2')`
   margin: 0;
 `
 
-export const TotalBlockedStatsText = styled<{}, 'span'>('span')`
+export const TotalBlockedStatsText = styled.span`
   box-sizing: border-box;
   font-size: 12px;
   font-weight: 500;
@@ -78,7 +78,7 @@ export const TotalBlockedStatsText = styled<{}, 'span'>('span')`
 /**
  * Interface/Privacy rows
  */
-export const BlockedInfoRowStats = styled<{}, 'span'>('span')`
+export const BlockedInfoRowStats = styled.span`
   box-sizing: border-box;
   color: ${palette.grey800};
   font-size: 14px;
@@ -86,7 +86,7 @@ export const BlockedInfoRowStats = styled<{}, 'span'>('span')`
   line-height: 1;
 `
 
-export const BlockedInfoRowText = styled<{}, 'span'>('span')`
+export const BlockedInfoRowText = styled.span`
   box-sizing: border-box;
   font-size: 12px;
   font-weight: 500;
@@ -97,7 +97,7 @@ export const BlockedInfoRowText = styled<{}, 'span'>('span')`
 /**
  * Blocked Lists
  */
-export const BlockedListSummaryText = styled<{}, 'span'>('span')`
+export const BlockedListSummaryText = styled.span`
   box-sizing: border-box;
   font-size: 14px;
   font-weight: 500;
@@ -105,14 +105,14 @@ export const BlockedListSummaryText = styled<{}, 'span'>('span')`
   color: ${palette.grey800};
 `
 
-export const BlockedListItemHeaderText = styled<{}, 'span'>('span')`
+export const BlockedListItemHeaderText = styled.span`
   box-sizing: border-box;
   font-weight: 500;
   color: ${palette.grey600};
   font-size: 12px;
 `
 
-export const BlockedListItemHeaderStats = styled<{}, 'span'>('span')`
+export const BlockedListItemHeaderStats = styled.span`
   text-align: center;
   font-size: 14px;
   color: ${palette.grey800};
@@ -122,7 +122,7 @@ export const BlockedListItemHeaderStats = styled<{}, 'span'>('span')`
 /**
  * Buttons that look like links
  */
-export const Link = styled<{}, 'button'>('button')`
+export const Link = styled.button`
   box-sizing: border-box;
   -webkit-appearance: none;
   color: ${palette.orange400};
@@ -165,7 +165,7 @@ export const LinkAction = styled(Link)`
   }
 `
 
-export const DisabledContentText = styled<{}, 'div'>('div')`
+export const DisabledContentText = styled.div`
   box-sizing: border-box;
   color: ${palette.grey500};
   font-size: 12px;

--- a/src/features/shields/media/index.ts
+++ b/src/features/shields/media/index.ts
@@ -3,7 +3,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import styled from '../../../theme'
-import { StyledComponentClass } from 'styled-components'
+import { StyledComponentBase } from 'styled-components'
 import { CaratDownIcon, ShieldAlertIcon } from '../../../components/icons'
 
 import { ComponentType } from 'react'
@@ -11,7 +11,7 @@ import palette from '../../../theme/colors'
 
 // rotated variants
 function RotatedIconComponent (
-  iconComponent: StyledComponentClass<any, any>,
+  iconComponent: StyledComponentBase<any, any>,
   degrees: number
 ) {
   return styled(iconComponent)`

--- a/src/features/shields/select/index.ts
+++ b/src/features/shields/select/index.ts
@@ -16,7 +16,7 @@ export interface SelectBoxProps {
   children: React.ReactNode
 }
 
-export const SelectBox = styled<SelectBoxProps, 'select'>('select')`
+export const SelectBox = styled.select<SelectBoxProps>`
   box-sizing: border-box;
   position: relative;
   -webkit-font-smoothing: antialiased;

--- a/src/features/shields/structure.ts
+++ b/src/features/shields/structure.ts
@@ -11,7 +11,7 @@ import { StyledWrapper as Toggle } from '../shields/toggle/style'
 /**
  * Main wrapper
  */
-export const ShieldsPanel = styled<{}, 'div'>('div')`
+export const ShieldsPanel = styled.div`
   box-sizing: border-box;
   -webkit-font-smoothing: antialiased;
   font-family: ${p => p.theme.fontFamily.heading};
@@ -27,7 +27,7 @@ interface ShieldsHeaderProps {
   status: 'enabled' | 'disabled'
 }
 
-export const ShieldsHeader = styled<ShieldsHeaderProps, 'header'>('header')`
+export const ShieldsHeader = styled.header<ShieldsHeaderProps>`
   box-sizing: border-box;
   background-image: url(${Background});
   background-repeat: no-repeat;
@@ -42,7 +42,7 @@ interface MainToggleProps {
   status: 'enabled' | 'disabled'
 }
 
-export const MainToggle = styled<MainToggleProps, 'section'>('section')`
+export const MainToggle = styled.section<MainToggleProps>`
   box-sizing: border-box;
   display: grid;
   grid-template-columns: 3fr 1fr;
@@ -64,7 +64,7 @@ interface SiteOverviewProps {
   status: 'enabled' | 'disabled'
 }
 
-export const SiteOverview = styled<SiteOverviewProps, 'div'>('div')`
+export const SiteOverview = styled.div<SiteOverviewProps>`
   box-sizing: border-box;
   display: grid;
   align-items: center;
@@ -73,7 +73,7 @@ export const SiteOverview = styled<SiteOverviewProps, 'div'>('div')`
   border-bottom: 1px solid ${p => p.status === 'enabled' ? 'rgba(160, 161, 178, 0.15)' : 'transparent'};
 `
 
-export const TotalBlockedStats = styled<{}, 'section'>('section')`
+export const TotalBlockedStats = styled.section`
   box-sizing: border-box;
   display: grid;
   grid-template-columns: 80px 140px;
@@ -82,7 +82,7 @@ export const TotalBlockedStats = styled<{}, 'section'>('section')`
   grid-gap: 10px;
 `
 
-export const SiteInfo = styled<{}, 'div'>('div')`
+export const SiteInfo = styled.div`
   box-sizing: border-box;
   display: grid;
   grid-template-columns: auto 1fr;
@@ -94,7 +94,7 @@ export const SiteInfo = styled<{}, 'div'>('div')`
 /**
  * Interface/privacy Rows
  */
-export const BlockedInfoRow = styled<{}, 'div'>('div')`
+export const BlockedInfoRow = styled.div`
   box-sizing: border-box;
   display: grid;
   grid-template-columns: 1fr auto;
@@ -134,7 +134,7 @@ interface BlockedInfoRowDataProps {
   disabled: boolean
 }
 
-export const BlockedInfoRowData = styled<BlockedInfoRowDataProps, 'div'>('div')`
+export const BlockedInfoRowData = styled.div<BlockedInfoRowDataProps>`
   display: grid;
   grid-template-columns: auto 36px 1fr;
   padding: 6px 0 5px 20px;
@@ -178,7 +178,7 @@ export const BlockedInfoRowDataForSelect = styled(BlockedInfoRowData)`
 /**
  * Footer
  */
-export const MainFooter = styled<{}, 'div'>('div')`
+export const MainFooter = styled.div`
   box-sizing: border-box;
   padding: 24px;
 `
@@ -186,7 +186,7 @@ export const MainFooter = styled<{}, 'div'>('div')`
 /**
  * Blocked Lists
  */
-export const BlockedListContent = styled<{}, 'div'>('div')`
+export const BlockedListContent = styled.div`
   box-sizing: border-box;
   position: absolute;
   top: 0;
@@ -198,7 +198,7 @@ export const BlockedListContent = styled<{}, 'div'>('div')`
   user-select: none;
 `
 
-export const BlockedListHeader = styled<{}, 'div'>('div')`
+export const BlockedListHeader = styled.div`
   display: grid;
   grid-template-columns: auto 1fr;
   grid-gap: 6px;
@@ -211,7 +211,7 @@ interface BlockedListSummaryProps {
   stats?: boolean
 }
 
-export const BlockedListSummary = styled<BlockedListSummaryProps, 'summary'>('summary')`
+export const BlockedListSummary = styled.summary<BlockedListSummaryProps>`
   &::-webkit-details-marker {
     display: none;
   }
@@ -234,7 +234,7 @@ export const BlockedListSummary = styled<BlockedListSummaryProps, 'summary'>('su
   }
 `
 
-export const BlockedListStatic = styled<{}, 'ul'>('ul')`
+export const BlockedListStatic = styled.ul`
   box-sizing: border-box;
   list-style-type: none;
   height: 307px;
@@ -247,7 +247,7 @@ export const BlockedListDynamic = styled(BlockedListStatic)`
   margin: 0;
 `
 
-export const BlockedListItemHeader = styled<{}, 'li'>('li')`
+export const BlockedListItemHeader = styled.li`
   box-sizing: border-box;
   position: sticky;
   top: 0;
@@ -266,13 +266,13 @@ export const BlockedListItemHeader = styled<{}, 'li'>('li')`
   }
 `
 
-export const BlockedListItem = styled<{}, 'li'>('li')`
+export const BlockedListItem = styled.li`
   box-sizing: border-box;
   padding: 9px 0px;
   line-height: 1;
 `
 
-export const BlockedListItemWithOptions = styled<{}, 'li'>('li')`
+export const BlockedListItemWithOptions = styled.li`
   box-sizing: border-box;
   display: grid;
   grid-template-columns: 1fr auto;
@@ -292,7 +292,7 @@ export const BlockedListItemWithOptions = styled<{}, 'li'>('li')`
   }
 `
 
-export const BlockedListFooter = styled<{}, 'footer'>('footer')`
+export const BlockedListFooter = styled.footer`
   box-sizing: border-box;
   padding: 12px 0px;
   display: flex;
@@ -300,7 +300,7 @@ export const BlockedListFooter = styled<{}, 'footer'>('footer')`
   border-top: 1px solid rgba(160, 161, 178, 0.15);
 `
 
-export const BlockedListFooterWithOptions = styled<{}, 'footer'>('footer')`
+export const BlockedListFooterWithOptions = styled.footer`
   box-sizing: border-box;
   display: flex;
   justify-content: space-between;
@@ -311,7 +311,7 @@ export const BlockedListFooterWithOptions = styled<{}, 'footer'>('footer')`
 /**
  * Disabled content
  */
-export const DisabledContentView = styled<{}, 'section'>('section')`
+export const DisabledContentView = styled.section`
   box-sizing: border-box;
   display: grid;
   grid-template-columns: 2fr 5fr;

--- a/src/features/shields/toggle/style.ts
+++ b/src/features/shields/toggle/style.ts
@@ -6,7 +6,7 @@ import styled, { css } from '../../../theme'
 import { Props } from './index'
 import palette from '../../../theme/colors'
 
-export const StyledCheckbox = styled<{}, 'input'>('input')`
+export const StyledCheckbox = styled.input`
   -webkit-appearance: none;
   position: absolute;
   z-index: 99999999;
@@ -19,13 +19,13 @@ export const StyledCheckbox = styled<{}, 'input'>('input')`
   outline-width: 2px;
 `
 
-export const StyledWrapper = styled<Props, 'div'>('div')`
+export const StyledWrapper = styled.div<Props>`
   box-sizing: border-box;
   display: flex;
   position: relative;
 `
 
-export const StyleToggle = styled<Props, 'div'>('div')`
+export const StyleToggle = styled.div<Props>`
   box-sizing: border-box;
   position: relative;
   display: block;
@@ -40,7 +40,7 @@ export const StyleToggle = styled<Props, 'div'>('div')`
   };
 `
 
-export const StyledSlider = styled<Props, 'label'>('label')`
+export const StyledSlider = styled.label<Props>`
   box-sizing: border-box;
   background: ${(p) => p.disabled ? 'rgba(246,246,250,0.1)' : '#C4C7C9'};
   height: ${(p) => p.size === 'small' ? '6px' : '8px'};
@@ -63,7 +63,7 @@ const transform = (p: Props) => {
 
 const transformBullet = (p: Props) => `${transform(p).x}, calc(-50% - ${transform(p).y})`
 
-export const StyledBullet = styled<Props, 'label'>('label')`
+export const StyledBullet = styled.label<Props>`
   box-sizing: border-box;
   position: relative;
   border-radius: 50%;

--- a/src/features/sync/grid/index.ts
+++ b/src/features/sync/grid/index.ts
@@ -4,11 +4,11 @@
 
 import styled from '../../../theme'
 
-export const SectionBlock = styled<{}, 'section'>('section')`
+export const SectionBlock = styled.section`
   margin: 15px 0 40px;
 `
 
-export const EnabledContentButtonGrid = styled<{}, 'footer'>('footer')`
+export const EnabledContentButtonGrid = styled.footer`
   display: grid;
   grid-template-columns: 1fr;
   grid-template-rows: 1fr;
@@ -16,7 +16,7 @@ export const EnabledContentButtonGrid = styled<{}, 'footer'>('footer')`
   margin: 10px 5px 0;
 `
 
-export const SettingsToggleGrid = styled<{}, 'footer'>('footer')`
+export const SettingsToggleGrid = styled.footer`
   display: grid;
   grid-template-columns: auto 1fr;
   grid-template-rows: 1fr;
@@ -25,7 +25,7 @@ export const SettingsToggleGrid = styled<{}, 'footer'>('footer')`
   margin: 15px 0 0;
 `
 
-export const DisabledContentButtonGrid = styled<{}, 'footer'>('footer')`
+export const DisabledContentButtonGrid = styled.footer`
   display: grid;
   grid-template-columns: 1fr 1fr;
   grid-template-rows: 1fr;
@@ -37,7 +37,7 @@ interface TableGridProps {
   isDeviceTable?: boolean
 }
 
-export const TableGrid = styled<TableGridProps, 'div'>('div')`
+export const TableGrid = styled.div<TableGridProps>`
   align-items: center;
   display: grid;
   grid-template-columns: ${p => p.isDeviceTable ? '1fr' : '200px auto'};
@@ -45,7 +45,7 @@ export const TableGrid = styled<TableGridProps, 'div'>('div')`
   grid-gap: ${p => p.isDeviceTable ? '0' : '50px'};
 `
 
-export const TableButtonGrid = styled<{}, 'div'>('div')`
+export const TableButtonGrid = styled.div`
   display: grid;
   grid-template-rows: auto;
   grid-gap: 15px;

--- a/src/features/sync/images/index.ts
+++ b/src/features/sync/images/index.ts
@@ -22,15 +22,15 @@ const deviceStyles = `
   height: 100px;
 `
 
-export const SyncStartIcon = styled<{}, 'img'>('img').attrs({ src: StartImageUrl })`
+export const SyncStartIcon = styled.img.attrs({ src: StartImageUrl })`
   max-width: 100%;
 `
-export const SyncDefaultIcon = styled<{}, 'img'>('img').attrs({ src: DefaultImageUrl })`${iconStyles}`
-export const SyncAddIcon = styled<{}, 'img'>('img').attrs({ src: AddImageUrl })`${iconStyles}`
-export const SyncRemoveIcon = styled<{}, 'img'>('img').attrs({ src: RemoveImageUrl })`${iconStyles}`
-export const SyncDesktopIcon = styled<{}, 'img'>('img').attrs({ src: DesktopImageUrl })`${deviceStyles}`
-export const SyncMobileIcon = styled<{}, 'img'>('img').attrs({ src: MobileImageUrl })`${deviceStyles}`
-export const SyncMobilePicture = styled<{}, 'img'>('img').attrs({ src: MobileHandImageUrl })`
+export const SyncDefaultIcon = styled.img.attrs({ src: DefaultImageUrl })`${iconStyles}`
+export const SyncAddIcon = styled.img.attrs({ src: AddImageUrl })`${iconStyles}`
+export const SyncRemoveIcon = styled.img.attrs({ src: RemoveImageUrl })`${iconStyles}`
+export const SyncDesktopIcon = styled.img.attrs({ src: DesktopImageUrl })`${deviceStyles}`
+export const SyncMobileIcon = styled.img.attrs({ src: MobileImageUrl })`${deviceStyles}`
+export const SyncMobilePicture = styled.img.attrs({ src: MobileHandImageUrl })`
   max-width: 100%;
   height: 150px;
   display: block;
@@ -40,7 +40,7 @@ interface QRCodeProps {
   size: 'normal' | 'small'
 }
 
-export const QRCode = styled<QRCodeProps, 'img'>('img')`
+export const QRCode = styled.img<QRCodeProps>`
   display: block;
   width: 200px;
   padding: 30px;

--- a/src/features/sync/misc/index.ts
+++ b/src/features/sync/misc/index.ts
@@ -5,7 +5,7 @@
 import styled from '../../../theme'
 import { Card } from '../../../components'
 
-export const DisabledContent = styled<{}, 'div'>('div')`
+export const DisabledContent = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -14,12 +14,12 @@ export const DisabledContent = styled<{}, 'div'>('div')`
   background-color: #efeff0;
 `
 
-export const EnabledContent = styled<{}, 'div'>('div')`
+export const EnabledContent = styled.div`
   height: inherit;
   background-color: #efeff0;
 `
 
-export const Main = styled<{}, 'main'>('main')`
+export const Main = styled.main`
   font-family: ${p => p.theme.fontFamily.body};
   color: ${p => p.theme.color.defaultControl};
   padding: 50px 15px;
@@ -31,13 +31,13 @@ export const SyncCard = styled(Card)`
   padding: 60px 80px;
 `
 
-export const TableRowId = styled<{}, 'span'>('span')`
+export const TableRowId = styled.span`
   width: 5ch;
   text-align: center;
   display: block;
 `
 
-export const TableRowDevice = styled<{}, 'span'>('span')`
+export const TableRowDevice = styled.span`
   max-width: 30ch;
   white-space: nowrap;
   overflow: hidden;
@@ -45,12 +45,12 @@ export const TableRowDevice = styled<{}, 'span'>('span')`
   display: block;
 `
 
-export const TableRowRemove = styled<{}, 'span'>('span')`
+export const TableRowRemove = styled.span`
   display: block;
   text-align: center;
 `
 
-export const TableRowRemoveButton = styled<{}, 'button'>('button')`
+export const TableRowRemoveButton = styled.button`
   text-align: center;
   padding: 0;
   border: 0;
@@ -61,7 +61,7 @@ export const TableRowRemoveButton = styled<{}, 'button'>('button')`
   width: 24px;
 `
 
-export const TableRowToggleButton = styled<{}, 'span'>('span')`
+export const TableRowToggleButton = styled.span`
   float: right;
   margin: 9px;
 `

--- a/src/features/sync/modal/index.ts
+++ b/src/features/sync/modal/index.ts
@@ -5,7 +5,7 @@
 import styled from '../../../theme'
 import Heading from '../../../components/text/heading'
 
-export const ModalHeader = styled<{}, 'header'>('header')`
+export const ModalHeader = styled.header`
   margin-bottom: 8px;
 `
 
@@ -20,23 +20,23 @@ interface ModalSubTitleProps {
   highlight?: boolean
 }
 
-export const ModalSubTitle = styled<ModalSubTitleProps, 'span'>('span')`
+export const ModalSubTitle = styled.span<ModalSubTitleProps>`
   display: block;
   font-size: 18px;
   line-height: 1.6;
   color: ${p => p.highlight && '#ff0000'}
 `
 
-export const ModalContent = styled<{}, 'div'>('div')`
+export const ModalContent = styled.div`
   margin-bottom: -12px;
 `
 
-export const OneColumnButtonGrid = styled<{}, 'div'>('div')`
+export const OneColumnButtonGrid = styled.div`
   display: flex;
   justify-content: flex-end;
 `
 
-export const TwoColumnButtonGrid = styled<{}, 'footer'>('footer')`
+export const TwoColumnButtonGrid = styled.footer`
   display: grid;
   align-items: center;
   grid-template-columns: 1fr auto;
@@ -44,7 +44,7 @@ export const TwoColumnButtonGrid = styled<{}, 'footer'>('footer')`
   margin-top: 20px;
 `
 
-export const ThreeColumnButtonGrid = styled<{}, 'div'>('div')`
+export const ThreeColumnButtonGrid = styled.div`
   display: grid;
   grid-template-columns: 1fr auto auto;
   grid-gap: 15px;
@@ -52,20 +52,20 @@ export const ThreeColumnButtonGrid = styled<{}, 'div'>('div')`
   align-items: center;
 `
 
-export const ThreeColumnButtonGridCol1 = styled<{}, 'div'>('div')`
+export const ThreeColumnButtonGridCol1 = styled.div`
   display: grid;
   align-items: center;
   grid-template-columns: auto;
 `
 
-export const ThreeColumnButtonGridCol2 = styled<{}, 'div'>('div')`
+export const ThreeColumnButtonGridCol2 = styled.div`
   display: grid;
   align-items: center;
   grid-template-columns: auto auto;
   grid-gap: 15px;
 `
 
-export const DeviceGrid = styled<{}, 'div'>('div')`
+export const DeviceGrid = styled.div`
   display: grid;
   grid-template-columns: 1fr 1fr;
   grid-template-rows: 1fr;
@@ -76,7 +76,7 @@ export const DeviceGrid = styled<{}, 'div'>('div')`
   justify-content: center;
 `
 
-export const DeviceContainer = styled<{}, 'a'>('a')`
+export const DeviceContainer = styled.a`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -87,7 +87,7 @@ export const DeviceContainer = styled<{}, 'a'>('a')`
   cursor: pointer;
 `
 
-export const ScanGrid = styled<{}, 'div'>('div')`
+export const ScanGrid = styled.div`
   display: grid;
   height: 100%;
   grid-template-columns: 1fr 1fr;
@@ -98,7 +98,7 @@ export const ScanGrid = styled<{}, 'div'>('div')`
   width: fit-content;
 `
 
-export const QRCodeContainer = styled<{}, 'div'>('div')`
+export const QRCodeContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -108,7 +108,7 @@ export const QRCodeContainer = styled<{}, 'div'>('div')`
   }
 `
 
-export const ViewSyncCodeGrid = styled<{}, 'div'>('div')`
+export const ViewSyncCodeGrid = styled.div`
   display: grid;
   height: 100%;
   grid-template-columns: 2fr 1fr;

--- a/src/features/sync/text/index.ts
+++ b/src/features/sync/text/index.ts
@@ -18,7 +18,7 @@ export const SubTitle = styled(Heading)`
   margin: 16px 0 12px 0;
 `
 
-export const Paragraph = styled<{}, 'p'>('p')`
+export const Paragraph = styled.p`
   font-size: 16px;
   font-weight: 300;
   line-height: 1.75;
@@ -27,7 +27,7 @@ export const Paragraph = styled<{}, 'p'>('p')`
   padding: 0 0 12px 0;
 `
 
-export const Link = styled<{}, 'a'>(Paragraph.withComponent('a') as any)`
+export const Link = styled.a`
   color: ${p => p.theme.color.subtle};
   padding: 0;
   text-decoration: none;
@@ -35,11 +35,11 @@ export const Link = styled<{}, 'a'>(Paragraph.withComponent('a') as any)`
   display: inline;
 `
 
-export const Bold = styled<{}, 'b'>('b')`
+export const Bold = styled.b`
   font-weight: 600;
 `
 
-export const SwitchLabel = styled<{}, 'label'>('label')`
+export const SwitchLabel = styled.label`
   font-family: ${p => p.theme.fontFamily.body};
   color: ${p => p.theme.color.defaultControlActive};
   font-size: 14px;

--- a/src/features/welcome/button/index.ts
+++ b/src/features/welcome/button/index.ts
@@ -9,7 +9,7 @@ interface BaseButtonProps {
   active?: boolean
 }
 
-const BaseButton = styled<BaseButtonProps, 'button'>('button')`
+const BaseButton = styled.button<BaseButtonProps>`
   box-sizing: border-box;
   padding: 0;
   margin: 0;

--- a/src/features/welcome/images/index.ts
+++ b/src/features/welcome/images/index.ts
@@ -12,7 +12,7 @@ import ShieldsImage from './welcome_shields.svg'
 import ThemeImage from './welcome_theme.svg'
 import WelcomeImage from './welcome_bg.svg'
 
-const BaseImage = styled<{}, 'img'>('img')`
+const BaseImage = styled.img`
   box-sizing: border-box;
   display: block;
   max-width: 100%;
@@ -56,7 +56,7 @@ export const topToBottom = keyframes`
   }
 `
 
-export const BackgroundContainer = styled<{}, 'div'>('div')`
+export const BackgroundContainer = styled.div`
   box-sizing: border-box;
   width: inherit;
   height: inherit;
@@ -70,7 +70,7 @@ export const BackgroundContainer = styled<{}, 'div'>('div')`
   overflow: hidden;
 `
 
-export const Background = styled<BackgroundProps, 'div'>('div')`
+export const Background = styled.div<BackgroundProps>`
   box-sizing: border-box;
   background: url('${WelcomeImage}') repeat-x;
   width: 500%;

--- a/src/features/welcome/text/index.ts
+++ b/src/features/welcome/text/index.ts
@@ -13,7 +13,7 @@ export const Title = styled(Heading)`
   line-height: 44px;
 `
 
-export const Paragraph = styled<{}, 'p'>('p')`
+export const Paragraph = styled.p`
   display: block;
   -webkit-font-smoothing: antialiased;
   font-size: 17px;

--- a/src/features/welcome/wrapper/index.ts
+++ b/src/features/welcome/wrapper/index.ts
@@ -14,13 +14,13 @@ const fadeIn = keyframes`
   }
 `
 
-const BaseGrid = styled<{}, 'div'>('div')`
+const BaseGrid = styled.div`
   box-sizing: border-box;
   display: grid;
   height: 100%;
 `
 
-const BaseColumn = styled<{}, 'div'>('div')`
+const BaseColumn = styled.div`
   box-sizing: border-box;
   position: relative;
   display: flex;
@@ -64,7 +64,7 @@ interface ContentProps {
   isPrevious: boolean
 }
 
-export const Content = styled<ContentProps, 'section'>('section')`
+export const Content = styled.section<ContentProps>`
   opacity: 0;
   will-change: transform;
   transform: translateX(${p => p.isPrevious ? '-' + p.screenPosition : p.screenPosition}) scale(0.8);
@@ -84,7 +84,7 @@ export const Content = styled<ContentProps, 'section'>('section')`
   `}
 `
 
-export const Page = styled<{}, 'div'>('div')`
+export const Page = styled.div`
   width: inherit%;
   height: inherit;
   display: flex;
@@ -116,7 +116,7 @@ export const Panel = styled(Card)`
   padding: 0;
 `
 
-export const SlideContent = styled<{}, 'div'>('div')`
+export const SlideContent = styled.div`
   max-width: inherit;
   min-height: 540px;
   display: flex;

--- a/src/old/headings/__snapshots__/spec.tsx.snap
+++ b/src/old/headings/__snapshots__/spec.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`all heading tests featureHeading tests basic tests matches the snapshot 1`] = `
-.c1 {
+.c0 {
   box-sizing: border-box;
   font-family: inherit;
   color: inherit;
@@ -11,9 +11,6 @@ exports[`all heading tests featureHeading tests basic tests matches the snapshot
   -ms-user-select: none;
   user-select: none;
   cursor: default;
-}
-
-.c0 {
   color: #444444;
   font-weight: normal;
   font-size: 14px;
@@ -22,7 +19,7 @@ exports[`all heading tests featureHeading tests basic tests matches the snapshot
 }
 
 <h2
-  className="c0 c1"
+  className="c0"
   id="testFeatureHeading"
 />
 `;
@@ -46,7 +43,7 @@ exports[`all heading tests heading tests basic tests matches the snapshot 1`] = 
 `;
 
 exports[`all heading tests sectionHeading tests basic tests matches the snapshot 1`] = `
-.c1 {
+.c0 {
   box-sizing: border-box;
   font-family: inherit;
   color: inherit;
@@ -56,9 +53,6 @@ exports[`all heading tests sectionHeading tests basic tests matches the snapshot
   -ms-user-select: none;
   user-select: none;
   cursor: default;
-}
-
-.c0 {
   color: rgb(68,68,68);
   font-size: 20px;
   margin: 0 0 20px;
@@ -66,13 +60,13 @@ exports[`all heading tests sectionHeading tests basic tests matches the snapshot
 }
 
 <h2
-  className="c0 c1"
+  className="c0"
   id="testSectionHeading"
 />
 `;
 
 exports[`all heading tests titleHeading tests basic tests matches the snapshot 1`] = `
-.c1 {
+.c0 {
   box-sizing: border-box;
   font-family: inherit;
   color: inherit;
@@ -82,9 +76,6 @@ exports[`all heading tests titleHeading tests basic tests matches the snapshot 1
   -ms-user-select: none;
   user-select: none;
   cursor: default;
-}
-
-.c0 {
   margin: 0;
   font-weight: 400;
   white-space: nowrap;
@@ -93,7 +84,7 @@ exports[`all heading tests titleHeading tests basic tests matches the snapshot 1
 }
 
 <h1
-  className="c0 c1"
+  className="c0"
   id="testTitleHeading"
 />
 `;

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -1,26 +1,18 @@
-// @ts-ignore: Needed for ThemeProvider
 import * as React from 'react'
 import * as styledComponents from 'styled-components'
 import IThemeProps, { BraveThemedStyledProps as ThemedStyledProps } from './theme-interface'
-// theme for testing
-import TestTheme from './brave-default'
+import TestTheme from './brave-default' // theme for testing
 
 const {
   default: styled,
   css,
-  injectGlobal,
+  createGlobalStyle,
   keyframes,
-  // React import is needed for following line!
   ThemeProvider
-  // tslint disabled because:
-  // - Incorrectly complains about unused assertion, but does not detect private member differences
-  //   see: https://github.com/palantir/tslint/issues/3505
-  //   It's possibly due to the rule upstream in tslint-config-standard
-  // tslint:disable-next-line
 } = styledComponents as styledComponents.ThemedStyledComponentsModule<IThemeProps>
 
 export default styled
 
 const TestThemeProvider = (props: any) => <ThemeProvider theme={TestTheme} {...props} />
 
-export { css, injectGlobal, keyframes, ThemeProvider, ThemedStyledProps, TestThemeProvider }
+export { css, createGlobalStyle, keyframes, ThemeProvider, ThemedStyledProps, TestThemeProvider }

--- a/stories/features/newTab/default/topSites/topSite.tsx
+++ b/stories/features/newTab/default/topSites/topSite.tsx
@@ -32,7 +32,7 @@ export default class TopSite extends React.PureComponent<Props, {}> {
       {
         (provided, snapshot) => (
           <Tile
-            innerRef={provided.innerRef}
+            ref={provided.innerRef}
             {...provided.draggableProps}
             {...provided.dragHandleProps}
             isDragging={snapshot.isDragging}

--- a/stories/features/newTab/default/topSites/topSitesList.tsx
+++ b/stories/features/newTab/default/topSites/topSitesList.tsx
@@ -42,7 +42,7 @@ export default class TopSitesList extends React.PureComponent<Props, State> {
         <Droppable droppableId='droppable' direction='horizontal'>
           {(provided) => {
             return (
-              <List {...provided.droppableProps} innerRef={provided.innerRef}>
+              <List {...provided.droppableProps} ref={provided.innerRef}>
                 {this.state.items.map((item, index) => <TopSite item={item} index={index} key={index} />)}
                 {provided.placeholder}
               </List>

--- a/stories/features/rewards/settingsMobile/style.ts
+++ b/stories/features/rewards/settingsMobile/style.ts
@@ -4,35 +4,35 @@
 
 import styled from 'styled-components'
 
-export const StyledListContent = styled<{}, 'div'>('div')`
+export const StyledListContent = styled.div`
   padding: 0 25px;
 `
 
-export const StyledSitesNum = styled<{}, 'div'>('div')`
+export const StyledSitesNum = styled.div`
   height: 50px;
   padding: 20px 25px;
   margin-top: -21px;
 `
 
-export const StyledDisabledContent = styled<{}, 'div'>('div')`
+export const StyledDisabledContent = styled.div`
   padding: 0px 5px;
 `
 
-export const StyledHeading = styled<{}, 'span'>('span')`
+export const StyledHeading = styled.span`
   font-size: 22px;
   font-weight: normal;
   letter-spacing: 0;
   line-height: 28px;
 `
 
-export const StyledSitesLink = styled<{}, 'a'>('a')`
+export const StyledSitesLink = styled.a`
   float: right;
   color: #4C54D2;
   font-size: 13px;
   letter-spacing: 0;
 `
 
-export const StyledText = styled<{}, 'p'>('p')`
+export const StyledText = styled.p`
   color: #838391;
   font-size: 14px;
   font-family: ${p => p.theme.fontFamily.body};
@@ -41,7 +41,7 @@ export const StyledText = styled<{}, 'p'>('p')`
   line-height: 28px;
 `
 
-export const StyledTotalContent = styled<{}, 'div'>('div')`
+export const StyledTotalContent = styled.div`
   position: relative;
   padding-right: 25px;
 
@@ -50,7 +50,7 @@ export const StyledTotalContent = styled<{}, 'div'>('div')`
   }
 `
 
-export const StyledWalletOverlay = styled<{}, 'div'>('div')`
+export const StyledWalletOverlay = styled.div`
   display: flex;
   position: fixed;
   top: 0;
@@ -63,14 +63,14 @@ export const StyledWalletOverlay = styled<{}, 'div'>('div')`
   justify-content: center;
 `
 
-export const StyledWalletWrapper = styled<{}, 'div'>('div')`
+export const StyledWalletWrapper = styled.div`
   height: 90vh;
   overflow-y: scroll;
   width: 90%;
   margin-top: 40px;
 `
 
-export const StyledWalletClose = styled<{}, 'div'>('div')`
+export const StyledWalletClose = styled.div`
   top: 15px;
   right: 15px;
   position: fixed;

--- a/tools/lib/templates.js
+++ b/tools/lib/templates.js
@@ -42,7 +42,7 @@ module.exports.style = () => `\
 
 import styled from 'styled-components'
 
-export const StyledWrapper = styled<{}, 'div'>('div')\`
+export const StyledWrapper = styled.div\`
   display: flex;
 \`
 `

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["react", "jest"],
     "target": "es6",
     "module": "esnext",
     "moduleResolution": "node",


### PR DESCRIPTION
Closes: https://github.com/brave/brave-ui/issues/128

Still needs tested for a successful build in Core. This builds in Brave UI but is on top of shields updates that still need wired up.  

## Syntax

### styled syntax

Across the board the new `styled-component` structure was updated:
```
V4
styled.div<Props>

V3
styled<Props, 'div'>('div)
```

### innerRef -> ref

With the updates I was getting errors on instances of `innerRef` instances and after [reading it was deprecated](https://www.styled-components.com/docs/api#deprecated-innerref-prop) the instances were switch to just `ref`

## Dependency Updates

1. `styled-components": ^4.1.3` - latest styled components release
2. ` @types/styled-components: ^4.1.10`: adds necessary TS definitions for v4
3. `typescript-plugin-styled-components: 1.2.0` - wouldn't work without it
4. `jest-styled-components": "^6.3.1" | "enzyme-adapter-react-16": "^1.10.0", |  "react-test-renderer": '^16.8.3"` - snapshots were breaking and not inheriting styles with v4. all 3 of these needed to be updated to get it to inherit the styled-component styles in the snapshot.
5. ts.config ->  `"types": ["react", "jest"], // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33311`: the "@types/styled-components" dependency (for some reason) inherits a react-native type definition folder. styled-components hates it and it triggers an error for duplicate type definitions. this fixes that error. read more: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33015