### PR TITLE
Update theme story styling

### DIFF
--- a/stories/components/theme.tsx
+++ b/stories/components/theme.tsx
@@ -3,49 +3,58 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import * as React from 'react'
-// Storybook requires
-import { storiesOf, setAddon } from '@storybook/react'
-// import { withKnobs, boolean, select } from '@storybook/addon-knobs'
-// @ts-ignore
-import chaptersAddon from 'react-storybook-addon-chapters'
-
-// Components
+import { storiesOf } from '@storybook/react'
 import styled from '../../src/theme'
 import paletteColors from '../../src/theme/colors'
 import themeBraveDefault from '../../src/theme/brave-default'
-import '../assets/fonts/muli.css'
 
-// wrappers
+const Palette = styled.div`
+  display: grid;
+  grid-gap: 8px;
+  grid-template-columns: repeat(10, 1fr);
+  @media only screen and (max-width: 1300px) {
+    grid-template-columns: repeat(5, 1fr);
+  }
+` as any
+
 const PaletteItemContainer = styled.div`
-  width: ${(p: any) => p.individual ? '25%' : '10%'};
   min-height: 150px;
-  margin: 5px;
-  border: 4px dotted #888;
   background: white;
-  padding: 2px;
+  padding: 4px;
   display: flex;
   flex-direction: column;
+  border-radius: 4px;
 ` as any
 
 const PaletteColor = styled.div`
-  flex-grow: 1;
-  flex-basis: 0;
+  display: flex;
+  height: 80px;
   background-color: ${p => p.color};
 `
 
 const PaletteItemName = styled.div`
-  font: 12px muli;
+  font-size: 14px;
   font-weight: 500;
-  color: #222;
   text-align: center;
+  margin: 8px 0 4px;
+  overflow: auto;
+`
+
+const PaletteItemHex = styled.div`
+  font-size: 10px;
+  font-weight: 600;
+  text-align: center;
+  text-transform: uppercase;
+  margin: 4px 0 8px;
 `
 
 const PaletteItem = ({ color, name, individual }: any) => (
   <PaletteItemContainer individual={individual}>
     <PaletteColor color={color} />
     <PaletteItemName>{name}</PaletteItemName>
+    <PaletteItemHex>{color}</PaletteItemHex>
   </PaletteItemContainer>
-) as any
+)
 
 const allPalletteItems: any = []
 for (const name in paletteColors) {
@@ -59,52 +68,20 @@ for (const name in themeBraveDefault.color) {
   allBraveDefaultItems.push({ name, color: themeBraveDefault.color[name] })
 }
 
-const Palette = styled.div`
-  display: flex;
-  flex-direction: ${(p: any) => p.individual ? 'column' : 'row'};
-  flex-wrap: wrap;
-  align-items: flex-start;
-` as any
-
-const sectionOptionsNoProps = {
-  showSource: false,
-  showPropTables: false,
-  allowPropTablesToggling: false
-}
-
-setAddon(chaptersAddon)
 storiesOf('Theme', module)
-  // @ts-ignore
-.addWithChapters('Palette', {
-  subtitle: 'Define colors by color name and shade, not by purpose',
-  chapters: [
-    {
-      title: 'All colors',
-      info: '_Avoid using directly. Instead use theme variables which link to these colors_',
-      sections: [{
-        sectionFn: () => (
-          <Palette>
-          {allPalletteItems.map(({ color, name }: any) => <PaletteItem key={name} color={color} name={name} />)}
-          </Palette>
-        ),
-        sectionOptionsNoProps
-      }]
-    }
-  ]
-})
-.addWithChapters('Brave Default', {
-  subtitle: 'Define colors, fonts, and sizes by purpose. Keys should not describe the value, but what they are to be used for.',
-  chapters: [
-    {
-      title: 'Color variables',
-      sections: [{
-        sectionFn: () => (
-          <Palette individual={true}>
-          {allBraveDefaultItems.map(({ color, name }: any) => <PaletteItem individual={true} key={name} color={color} name={name} />)}
-          </Palette>
-        ),
-        sectionOptionsNoProps
-      }]
-    }
-  ]
-})
+  .add('Colors', () => {
+    return (
+      <Palette>
+        {allPalletteItems.map(({ color, name }: any) => <PaletteItem key={name} color={color} name={name} />)}
+      </Palette>
+    )
+  })
+
+  .add('Theme Variables', () => {
+    return (
+      <Palette individual={true}>
+        {allBraveDefaultItems.map(({ color, name }: any) =>
+          <PaletteItem individual={true} key={name} color={color} name={name} />)}
+      </Palette>
+    )
+  })


### PR DESCRIPTION
Just some general storybook polish. No issue tied to this one. Added a hex value to the cards. Removed the chapters addon reference as we are going to move to documentation outside of storybook in some capacity.

## Before
![screen shot 2019-03-02 at 4 05 47 pm](https://user-images.githubusercontent.com/29072694/53689337-2584be80-3d08-11e9-85db-34676530f071.png)


## After

![screen shot 2019-03-02 at 4 23 34 pm](https://user-images.githubusercontent.com/29072694/53689341-464d1400-3d08-11e9-91ab-b259497056e1.png)

