### PR TITLE
Adding selectMobile component

### DIFF
--- a/src/features/rewards/mobile/index.ts
+++ b/src/features/rewards/mobile/index.ts
@@ -4,12 +4,14 @@
 
 import BoxMobile from './boxMobile'
 import MainToggleMobile from './mainToggleMobile'
+import SelectMobile from './selectMobile'
 import SettingsPageMobile from './settingsPageMobile'
 import WalletInfoHeader from './walletInfoHeader'
 
 export {
   BoxMobile,
   MainToggleMobile,
+  SelectMobile,
   SettingsPageMobile,
   WalletInfoHeader
 }

--- a/src/features/rewards/mobile/selectMobile/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/mobile/selectMobile/__snapshots__/spec.tsx.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SelectMobile tests basic tests matches the snapshot 1`] = `
+.c0 {
+  width: 100%;
+  background: #fff;
+  height: 34px;
+  font-size: 14px;
+  border: 1px solid #DFDFE8;
+  text-align-last: left;
+}
+
+.c0:focus {
+  outline: 0;
+}
+
+<select
+  className="c0"
+  onChange={[Function]}
+/>
+`;

--- a/src/features/rewards/mobile/selectMobile/index.tsx
+++ b/src/features/rewards/mobile/selectMobile/index.tsx
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as React from 'react'
+import {
+  StyledSelect
+} from './style'
+import { getLocale } from '../../../../helpers'
+
+export type Amount = {
+  value: string
+  dataValue: string
+  converted: string
+}
+
+export type Option = {
+  value: string
+  text: string
+}
+
+export interface Props {
+  value?: string
+  options?: Option[]
+  floating?: boolean
+  amountOptions?: Amount[]
+  onChange?: (value: string) => void
+}
+
+export default class SelectMobile extends React.PureComponent<Props, {}> {
+
+  onChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    if (this.props.onChange) {
+      this.props.onChange(event.target.value)
+    }
+  }
+
+  generateOptions = (options?: Option[]) => {
+    if (!options) {
+      return null
+    }
+
+    return (
+      <>
+        {options.map((option: Option) => {
+          return (
+            <option
+              value={option.value}
+              key={`k-${option.value}`}
+            >
+              {option.text}
+            </option>
+          )
+        })}
+      </>
+    )
+  }
+
+  generateAmountOptions = (amountOptions?: Amount[]) => {
+    if (!amountOptions) {
+      return null
+    }
+
+    return (
+      <>
+        {amountOptions.map((amount: Amount) => {
+          return (
+            <option
+              key={`k-${amount.value}`}
+              value={amount.dataValue}
+            >
+              {amount.value} {getLocale('bat')} ({amount.converted} USD)
+            </option>
+          )
+        })}
+      </>
+    )
+  }
+
+  render () {
+    const { options, floating, amountOptions, value } = this.props
+
+    return (
+      <StyledSelect value={value} onChange={this.onChange} floating={floating}>
+        {
+          amountOptions
+          ? this.generateAmountOptions(amountOptions)
+          : this.generateOptions(options)
+        }
+      </StyledSelect>
+    )
+  }
+}

--- a/src/features/rewards/mobile/selectMobile/spec.tsx
+++ b/src/features/rewards/mobile/selectMobile/spec.tsx
@@ -1,0 +1,24 @@
+/* global jest, expect, describe, it, afterEach */
+import * as React from 'react'
+import { shallow } from 'enzyme'
+import { create } from 'react-test-renderer'
+import SelectMobile from './index'
+import { TestThemeProvider } from '../../../../theme'
+
+describe('SelectMobile tests', () => {
+  const baseComponent = (props?: object) => <TestThemeProvider><SelectMobile id='selectMobile' {...props} /></TestThemeProvider>
+
+  describe('basic tests', () => {
+    it('matches the snapshot', () => {
+      const component = baseComponent()
+      const tree = create(component).toJSON()
+      expect(tree).toMatchSnapshot()
+    })
+
+    it('renders the component', () => {
+      const wrapper = shallow(baseComponent())
+      const assertion = wrapper.find('#selectMobile').length
+      expect(assertion).toBe(1)
+    })
+  })
+})

--- a/src/features/rewards/mobile/selectMobile/style.ts
+++ b/src/features/rewards/mobile/selectMobile/style.ts
@@ -1,0 +1,18 @@
+import styled from 'styled-components'
+
+interface StyleProps {
+  floating?: boolean
+}
+
+export const StyledSelect = styled<StyleProps, 'select'>('select')`
+  width: 100%;
+  background: #fff;
+  height: 34px;
+  font-size: 14px;
+  border: ${p => p.floating ? 'none' : '1px solid #DFDFE8'};
+  text-align-last: ${p => p.floating ? 'right' : 'left'};
+
+  &:focus {
+    outline: 0;
+  }
+`

--- a/stories/features/rewards/settingsMobile/contributeBoxMobile.tsx
+++ b/stories/features/rewards/settingsMobile/contributeBoxMobile.tsx
@@ -17,8 +17,8 @@ import {
   StyledTotalContent,
   StyledSitesLink
 } from './style'
-import { Column, Grid, Select, ControlWrapper, Checkbox } from '../../../../src/components'
-import { BoxMobile } from '../../../../src/features/rewards/mobile'
+import { Column, Grid, ControlWrapper, Checkbox } from '../../../../src/components'
+import { BoxMobile, SelectMobile } from '../../../../src/features/rewards/mobile'
 import { DetailRow as ContributeDetailRow } from '../../../../src/features/rewards/tableContribute'
 
 // Utils
@@ -61,6 +61,10 @@ class ContributeBoxMobile extends React.Component<Props, State> {
     })
   }
 
+  onSelectSettingChange = (key: string, value: string) => {
+    console.log(`${key} is now ${value}`)
+  }
+
   doNothing = () => {
     console.log('nothing')
   }
@@ -71,26 +75,74 @@ class ContributeBoxMobile extends React.Component<Props, State> {
         <Grid columns={1} customStyle={{ maxWidth: '270px', margin: '0 auto' }}>
             <Column size={1} customStyle={{ justifyContent: 'center', flexWrap: 'wrap' }}>
               <ControlWrapper text={locale.contributionMonthly}>
-                <Select title={locale.contributionMonthly}>
-                  <div data-value='10'><Tokens value={'10.0'} converted={'4.00'}/></div>
-                  <div data-value='20'><Tokens value={'20.0'} converted={'6.00'}/></div>
-                  <div data-value='40'><Tokens value={'40.0'} converted={'12.00'}/></div>
-                  <div data-value='100'><Tokens value={'100.0'} converted={'40.00'}/></div>
-                </Select>
+                <SelectMobile
+                  onChange={this.onSelectSettingChange.bind(this, 'contributionMonthly')}
+                  amountOptions={[
+                    {
+                      value: '10.0',
+                      dataValue: '10',
+                      converted: '4.00'
+                    },
+                    {
+                      value: '20.0',
+                      dataValue: '20',
+                      converted: '6.00'
+                    },
+                    {
+                      value: '40.0',
+                      dataValue: '40',
+                      converted: '12.00'
+                    },
+                    {
+                      value: '60.0',
+                      dataValue: '60',
+                      converted: '17.00'
+                    },
+                    {
+                      value: '100.0',
+                      dataValue: '100',
+                      converted: '30.00'
+                    }
+                  ]}
+                />
               </ControlWrapper>
               <ControlWrapper text={locale.contributionMinTime}>
-                <Select title={locale.contributionMinTime}>
-                  <div data-value='5'>{locale.contributionTime5}</div>
-                  <div data-value='8'>{locale.contributionTime8}</div>
-                  <div data-value='60'>{locale.contributionTime60}</div>
-                </Select>
+                <SelectMobile
+                  onChange={this.onSelectSettingChange.bind(this, 'contributionMinTime')}
+                  options={[
+                    {
+                      value: '5',
+                      text: locale.contributionTime5
+                    },
+                    {
+                      value: '8',
+                      text: locale.contributionTime8
+                    },
+                    {
+                      value: '60',
+                      text: locale.contributionTime60
+                    }
+                  ]}
+                />
               </ControlWrapper>
               <ControlWrapper text={locale.contributionMinVisits}>
-                <Select title={locale.contributionMinVisits}>
-                  <div data-value='5'>{locale.contributionVisit1}</div>
-                  <div data-value='8'>{locale.contributionVisit5}</div>
-                  <div data-value='60'>{locale.contributionVisit10}</div>
-                </Select>
+                <SelectMobile
+                  onChange={this.onSelectSettingChange.bind(this, 'contributionMinVisits')}
+                  options={[
+                    {
+                      value: '1',
+                      text: locale.contributionVisit1
+                    },
+                    {
+                      value: '5',
+                      text: locale.contributionVisit5
+                    },
+                    {
+                      value: '10',
+                      text: locale.contributionVisit10
+                    }
+                  ]}
+                />
               </ControlWrapper>
               <ControlWrapper text={locale.contributionAllowed}>
                 <Checkbox
@@ -227,16 +279,37 @@ class ContributeBoxMobile extends React.Component<Props, State> {
       >
         <List title={<StyledListContent>{locale.contributionMonthly}</StyledListContent>}>
           <StyledListContent>
-            <Select
+            <SelectMobile
               floating={true}
-              title={locale.contributionMonthly}
-            >
-              <div data-value='10'><Tokens value={'10.0'} converted={'4.00'}/></div>
-              <div data-value='20'><Tokens value={'20.0'} converted={'6.00'}/></div>
-              <div data-value='40'><Tokens value={'40.0'} converted={'12.00'}/></div>
-              <div data-value='40'><Tokens value={'60.0'} converted={'12.00'}/></div>
-              <div data-value='100'><Tokens value={'100.0'} converted={'40.00'}/></div>
-            </Select>
+              onChange={this.onSelectSettingChange.bind(this, 'contributionMonthly')}
+              amountOptions={[
+                {
+                  value: '10.0',
+                  dataValue: '10',
+                  converted: '4.00'
+                },
+                {
+                  value: '20.0',
+                  dataValue: '20',
+                  converted: '6.00'
+                },
+                {
+                  value: '40.0',
+                  dataValue: '40',
+                  converted: '12.00'
+                },
+                {
+                  value: '60.0',
+                  dataValue: '60',
+                  converted: '17.00'
+                },
+                {
+                  value: '100.0',
+                  dataValue: '100',
+                  converted: '30.00'
+                }
+              ]}
+            />
           </StyledListContent>
         </List>
         <List title={<StyledListContent>{locale.contributionNextDate}</StyledListContent>}>


### PR DESCRIPTION
Functionality for the new component should be in parity with the `Select` that we have been using.

For mobile it is important that the genuine `<select><option>..</select>` is used so mobile selector comes up when it is time to change options.

Related android issues:
https://github.com/brave/browser-android-tabs/issues/1234
https://github.com/brave/browser-android-tabs/issues/1202
https://github.com/brave/browser-android-tabs/issues/1133

<img width="483" alt="screen shot 2019-03-05 at 4 05 11 pm" src="https://user-images.githubusercontent.com/8732757/53843826-f0bf7400-3f60-11e9-83b2-5f07f3e72de9.png">


## Changes

## Test plan


##### Link / storybook path to visual changes
https://brave-ui-asrpecz3f.now.sh

## Integration
- [ ] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [ ] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [ ] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
