### PR TITLE
Add data-test-id attributes for Rewards testing

### DIFF
--- a/src/components/formControls/checkbox/index.tsx
+++ b/src/components/formControls/checkbox/index.tsx
@@ -12,6 +12,7 @@ export type Size = 'big' | 'small'
 export interface Props {
   value: {[key: string]: boolean}
   id?: string
+  testId?: string
   children: React.ReactNode
   multiple?: boolean
   disabled?: boolean
@@ -84,7 +85,7 @@ export default class Checkbox extends React.PureComponent<Props, {}> {
   }
 
   render () {
-    const { id, children } = this.props
+    const { id, testId, children } = this.props
     const num = React.Children.count(children)
     let data = null
 
@@ -93,7 +94,7 @@ export default class Checkbox extends React.PureComponent<Props, {}> {
     }
 
     return (
-      <div id={id}>
+      <div id={id} data-test-id={testId}>
         {data}
       </div>
     )

--- a/src/features/rewards/grantClaim/index.tsx
+++ b/src/features/rewards/grantClaim/index.tsx
@@ -11,6 +11,7 @@ export type Type = 'ads' | 'ugp'
 
 export interface Props {
   id?: string
+  testId?: string
   isMobile?: boolean
   onClaim: () => void
   type: Type
@@ -53,7 +54,7 @@ export default class GrantClaim extends React.PureComponent<Props, {}> {
   }
 
   render () {
-    const { id, isMobile, onClaim, type, amount, loading } = this.props
+    const { id, testId, isMobile, onClaim, type, amount, loading } = this.props
 
     return (
       <StyledWrapper
@@ -66,7 +67,7 @@ export default class GrantClaim extends React.PureComponent<Props, {}> {
         <StyledText>
           {this.getGrantText(type, amount)}
         </StyledText>
-        <StyledClaim onClick={onClaim}>
+        <StyledClaim onClick={onClaim} data-test-id={testId}>
           {
             loading
             ? <StyledLoader>

--- a/src/features/rewards/grantComplete/index.tsx
+++ b/src/features/rewards/grantComplete/index.tsx
@@ -16,6 +16,7 @@ import Button from '../../../components/buttonsIndicators/button'
 
 export interface Props {
   id?: string
+  testId?: string
   onClose: () => void
   amount: string
   date: string,
@@ -24,10 +25,10 @@ export interface Props {
 
 export default class GrantComplete extends React.PureComponent<Props, {}> {
   render () {
-    const { id, onClose, amount, date, isMobile } = this.props
+    const { id, testId, onClose, amount, date, isMobile } = this.props
 
     return (
-      <StyledWrapper id={id}>
+      <StyledWrapper id={id} data-test-id={testId}>
         <StyledBox>
           <StyledTitle>{getLocale('newTokenGrant')}</StyledTitle>
           <StyledValue>{amount} BAT</StyledValue>

--- a/src/features/rewards/grantWrapper/index.tsx
+++ b/src/features/rewards/grantWrapper/index.tsx
@@ -12,6 +12,7 @@ import giftIconUrl from './assets/gift.svg'
 
 export interface Props {
   id?: string
+  testId?: string
   isPanel?: boolean
   onClose: () => void
   title: string
@@ -23,11 +24,12 @@ export interface Props {
 
 export default class GrantWrapper extends React.PureComponent<Props, {}> {
   render () {
-    const { id, isPanel, fullScreen, hint, onClose, title, text, children } = this.props
+    const { id, testId, isPanel, fullScreen, hint, onClose, title, text, children } = this.props
 
     return (
       <StyledWrapper
         id={id}
+        data-test-id={testId}
         isPanel={isPanel}
         fullScreen={fullScreen}
       >

--- a/src/features/rewards/siteBanner/index.tsx
+++ b/src/features/rewards/siteBanner/index.tsx
@@ -292,6 +292,7 @@ export default class SiteBanner extends React.PureComponent<Props, State> {
                   !recurringDonation
                     ? <StyledCheckbox isMobile={isMobile}>
                       <Checkbox
+                        testId={'monthlyCheckbox'}
                         value={{ make: this.state.monthly }}
                         onChange={this.onMonthlyChange}
                         type={'dark'}

--- a/src/features/rewards/tableContribute/index.tsx
+++ b/src/features/rewards/tableContribute/index.tsx
@@ -39,6 +39,7 @@ export interface Props {
   showRowAmount?: boolean
   showRemove?: boolean
   id?: string
+  testId?: string
   children?: React.ReactNode
   headerColor?: boolean
   rows?: DetailRow[]
@@ -173,11 +174,11 @@ export default class TableContribute extends React.PureComponent<Props, {}> {
   }
 
   render () {
-    const { id, header, children, rows, allSites, onShowAll, onRestore, numExcludedSites } = this.props
+    const { id, testId, header, children, rows, allSites, onShowAll, onRestore, numExcludedSites } = this.props
     const numSites = this.props.numSites || 0
 
     return (
-      <div id={id}>
+      <div id={id} data-test-id={testId}>
         <Table
           header={this.getHeader(header)}
           children={children}

--- a/src/features/rewards/walletWrapper/index.tsx
+++ b/src/features/rewards/walletWrapper/index.tsx
@@ -453,7 +453,7 @@ export default class WalletWrapper extends React.PureComponent<Props, State> {
                       : null
                   }
                   <StyledBalance>
-                    <StyledBalanceTokens>
+                    <StyledBalanceTokens data-test-id='balance'>
                       {balance} <StyledBalanceCurrency>BAT</StyledBalanceCurrency>
                     </StyledBalanceTokens>
                     {


### PR DESCRIPTION
Fixes #417

This adds several `data-test-id` attributes required by the Rewards browser tests.
It's a prerequisite for brave/brave-browser#3161.