### PR TITLE
Adding hideAddFundsText prop to WalletEmpty

### DIFF
--- a/src/features/rewards/walletEmpty/index.tsx
+++ b/src/features/rewards/walletEmpty/index.tsx
@@ -3,25 +3,36 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import * as React from 'react'
-import { StyledWrapper, StyledTitle, StyledContent } from './style'
+import { StyledWrapper, StyledTitle, StyledContent, StyledCenter } from './style'
 import { getLocale } from '../../../helpers'
 import coins from './assets/coins'
 
 interface Props {
   id?: string
+  hideAddFundsText?: boolean
 }
 
 export default class WalletEmpty extends React.PureComponent<Props, {}> {
   render () {
+    const { id, hideAddFundsText } = this.props
+
     return (
-      <StyledWrapper id={this.props.id}>
+      <StyledWrapper id={id}>
         {coins}
         <StyledTitle>{getLocale('rewardsPanelEmptyText1')}</StyledTitle>
         <StyledContent>
-          <b>{getLocale('rewardsPanelEmptyText2')}</b><br/>
-          • {getLocale('rewardsPanelEmptyText3')}<br/>
-          • {getLocale('rewardsPanelEmptyText4')}<br/>
-          • {getLocale('rewardsPanelEmptyText5')}
+          {
+            hideAddFundsText
+            ? <StyledCenter>
+                {getLocale('rewardsPanelEmptyText5')}
+              </StyledCenter>
+            : <>
+                <b>{getLocale('rewardsPanelEmptyText2')}</b><br/>
+                • {getLocale('rewardsPanelEmptyText3')}<br/>
+                • {getLocale('rewardsPanelEmptyText4')}<br/>
+                • {getLocale('rewardsPanelEmptyText5')}
+              </>
+          }
         </StyledContent>
       </StyledWrapper>
     )

--- a/src/features/rewards/walletEmpty/style.ts
+++ b/src/features/rewards/walletEmpty/style.ts
@@ -33,3 +33,7 @@ export const StyledContent = styled<{}, 'div'>('div')`
     color: #686978;
   }
 `
+
+export const StyledCenter = styled<{}, 'div'>('div')`
+  text-align: center;
+` as any

--- a/stories/assets/locale.ts
+++ b/stories/assets/locale.ts
@@ -154,7 +154,7 @@ const locale: Record<string, string> = {
   rewardsPanelEmptyText2: '3 ways to fill your wallet:',
   rewardsPanelEmptyText3: 'You can add funds.',
   rewardsPanelEmptyText4: 'You can earn tokens from Brave Ads.',
-  rewardsPanelEmptyText5: 'Occasionally, you will also received token grants from Brave. So keep an eye out for the alert!',
+  rewardsPanelEmptyText5: 'Occasionally, you\'ll be offered free token grants from Brave. Be sure to keep an eye out for the alert!',
   rewardsPanelOffText1: 'Get Rewarded for Browsing!',
   rewardsPanelOffText2: 'Earn tokens for your attention to ads and pay it forward to support content creators you value!',
   rewardsPanelText1: 'Add, withdraw and manage funds at',

--- a/stories/features/rewards/settingsMobile/mobileWalletPanel.tsx
+++ b/stories/features/rewards/settingsMobile/mobileWalletPanel.tsx
@@ -5,7 +5,7 @@
 import * as React from 'react'
 import { boolean, object } from '@storybook/addon-knobs'
 
-import { WalletSummary, WalletWrapper } from '../../../../src/features/rewards'
+import { WalletEmpty, WalletWrapper } from '../../../../src/features/rewards'
 import { StyledWalletClose, StyledWalletOverlay, StyledWalletWrapper } from './style'
 import { CloseStrokeIcon, WalletAddIcon } from '../../../../src/components/icons'
 import ModalAddFunds, { Address } from '../../../../src/features/rewards/modalAddFunds'
@@ -110,17 +110,7 @@ class MobileWalletPanel extends React.Component<Props, State> {
               ])}
               connectedWallet={boolean('Connected wallet', false)}
             >
-              <WalletSummary
-                report={{
-                  grant: { tokens: '10.0', converted: '0.25' },
-                  ads: { tokens: '10.0', converted: '0.25' },
-                  deposit: { tokens: '10.0', converted: '0.25' },
-                  contribute: { tokens: '10.0', converted: '0.25' },
-                  donation: { tokens: '2.0', converted: '0.25' },
-                  tips: { tokens: '19.0', converted: '5.25' }
-                }}
-                onActivity={doNothing}
-              />
+              <WalletEmpty hideAddFundsText={true} />
             </WalletWrapper>
           </StyledWalletWrapper>
           {


### PR DESCRIPTION
Related: https://github.com/brave/browser-android-tabs/issues/1315

https://brave-ui-cifavwm5h.now.sh

<img width="422" alt="Screen Shot 2019-03-13 at 9 57 12 AM" src="https://user-images.githubusercontent.com/8732757/54298976-1a872500-4577-11e9-91c1-f25802566176.png">

## Integration
- [ ] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [ ] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [ ] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
