### PR TITLE
Changing tipsMigrationAlert -> boxAlert, adding Ads variant

### DIFF
--- a/src/features/rewards/boxAlert/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/boxAlert/__snapshots__/spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TipsMigrationAlert tests basic tests matches the snapshot 1`] = `
+exports[`BoxAlert tests basic tests matches the snapshot 1`] = `
 .c0 {
   width: 100%;
   display: -webkit-box;
@@ -27,9 +27,21 @@ exports[`TipsMigrationAlert tests basic tests matches the snapshot 1`] = `
   -ms-letter-spacing: 0;
   letter-spacing: 0;
   line-height: 18px;
-  padding: 12px 15px 0px 11px;
   vertical-align: top;
   max-width: 387px;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding-left: 5px;
 }
 
 .c4 {
@@ -37,30 +49,6 @@ exports[`TipsMigrationAlert tests basic tests matches the snapshot 1`] = `
   margin-right: 3px;
   font-weight: 400;
   font-size: inherit;
-}
-
-.c5 {
-  color: #696FDC;
-  font-weight: 400;
-  display: inline-block;
-  font-size: inherit;
-}
-
-.c6 {
-  vertical-align: top;
-  margin: 20px 0 0 7px;
-}
-
-.c7 {
-  color: #15A4FA;
-  cursor: pointer;
-  font-size: 14px;
-  font-weight: 500;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  line-height: 18px;
 }
 
 .c2 {
@@ -92,22 +80,7 @@ exports[`TipsMigrationAlert tests basic tests matches the snapshot 1`] = `
     <span
       className="c4"
     >
-      MISSING: reviewSitesMsg
-    </span>
-    <span
-      className="c5"
-    >
-      MISSING: monthlyTips
-    </span>
-  </div>
-  <div
-    className="c6"
-  >
-    <span
-      className="c7"
-      onClick={[Function]}
-    >
-      MISSING: learnMore
+      MISSING: adsNotSupported
     </span>
   </div>
 </div>

--- a/src/features/rewards/boxAlert/index.tsx
+++ b/src/features/rewards/boxAlert/index.tsx
@@ -29,16 +29,19 @@ import { Modal } from '../../../components'
 import { AlertCircleIcon, RewardsSendTipsIcon } from '../../../components/icons'
 import Button from '../../../components/buttonsIndicators/button'
 
+export type Type = 'tips' | 'ads'
+
 export interface Props {
+  type: Type
   testId?: string
-  onReview: () => void
+  onReview?: () => void
 }
 
 interface State {
   modalShown: boolean
 }
 
-export default class TipsMigrationAlert extends React.PureComponent<Props, State> {
+export default class BoxAlert extends React.PureComponent<Props, State> {
   constructor (props: Props) {
     super(props)
     this.state = {
@@ -108,28 +111,40 @@ export default class TipsMigrationAlert extends React.PureComponent<Props, State
   }
 
   render () {
-    const { testId } = this.props
+    const { testId, type } = this.props
 
     return (
       <StyledWrapper data-test-id={testId}>
         <StyledAlertIcon>
           <AlertCircleIcon />
         </StyledAlertIcon>
-        <StyledInfo>
-          <StyledMessage>
-            {getLocale('reviewSitesMsg')}
-          </StyledMessage>
-          <StyledMonthlyTips>
-            {getLocale('monthlyTips')}
-          </StyledMonthlyTips>
+        <StyledInfo type={type}>
+          {
+            type === 'tips'
+            ? <>
+                <StyledMessage>
+                  {getLocale('reviewSitesMsg')}
+                </StyledMessage>
+                <StyledMonthlyTips>
+                  {getLocale('monthlyTips')}
+                </StyledMonthlyTips>
+              </>
+            : <StyledMessage>
+                {getLocale('adsNotSupported')}
+              </StyledMessage>
+          }
         </StyledInfo>
-        <StyledReviewWrapper>
-          <StyledReviewList onClick={this.toggleModalDisplay}>
-            {getLocale('learnMore')}
-          </StyledReviewList>
-        </StyledReviewWrapper>
         {
-          this.state.modalShown
+          type === 'tips'
+          ? <StyledReviewWrapper>
+              <StyledReviewList onClick={this.toggleModalDisplay}>
+                {getLocale('learnMore')}
+              </StyledReviewList>
+            </StyledReviewWrapper>
+          : null
+        }
+        {
+          this.state.modalShown && type === 'tips'
           ? this.pinnedSitesModal()
           : null
         }

--- a/src/features/rewards/boxAlert/spec.tsx
+++ b/src/features/rewards/boxAlert/spec.tsx
@@ -6,11 +6,11 @@
 import * as React from 'react'
 import { shallow } from 'enzyme'
 import { create } from 'react-test-renderer'
-import TipsMigrationAlert from './index'
+import BoxAlert from './index'
 import { TestThemeProvider } from '../../../theme'
 
-describe('TipsMigrationAlert tests', () => {
-  const baseComponent = (props?: object) => <TestThemeProvider><TipsMigrationAlert id='tipsmigrationalert' {...props} /></TestThemeProvider>
+describe('BoxAlert tests', () => {
+  const baseComponent = (props?: object) => <TestThemeProvider><BoxAlert id='box-alert' {...props} /></TestThemeProvider>
 
   describe('basic tests', () => {
     it('matches the snapshot', () => {
@@ -21,7 +21,7 @@ describe('TipsMigrationAlert tests', () => {
 
     it('renders the component', () => {
       const wrapper = shallow(baseComponent())
-      const assertion = wrapper.find('#tipsmigrationalert').length
+      const assertion = wrapper.find('#box-alert').length
       expect(assertion).toBe(1)
     })
   })

--- a/src/features/rewards/boxAlert/style.ts
+++ b/src/features/rewards/boxAlert/style.ts
@@ -3,10 +3,12 @@
 * You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
+import { Type } from './index'
 import styled from 'styled-components'
 
 interface StyleProps {
   modal?: boolean
+  type?: Type
 }
 
 export const StyledWrapper = styled<{}, 'div'>('div')`
@@ -25,13 +27,16 @@ export const StyledAlertIcon = styled<{}, 'div'>('div')`
   color: #15A4FA;
 `
 
-export const StyledInfo = styled<{}, 'div'>('div')`
+export const StyledInfo = styled<StyleProps, 'div'>('div')`
   font-size: 14px;
   letter-spacing: 0;
   line-height: 18px;
-  padding: 12px 15px 0px 11px;
   vertical-align: top;
   max-width: 387px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding-left: 5px;
 `
 
 export const StyledMessage = styled<StyleProps, 'span'>('span')`

--- a/src/features/rewards/index.ts
+++ b/src/features/rewards/index.ts
@@ -5,6 +5,7 @@
 import Alert from './alert'
 import Amount from './amount'
 import Box from './box'
+import BoxAlert from './boxAlert'
 import DisabledContent from './disabledContent'
 import DisabledPanel from './disabledPanel'
 import Donate from './donate'
@@ -35,7 +36,6 @@ import TableContribute from './tableContribute'
 import TableDonation from './tableDonation'
 import TableTransactions from './tableTransactions'
 import Tip from './tip'
-import TipsMigrationAlert from './tipsMigrationAlert'
 import ToggleTips from './toggleTips'
 import Tokens from './tokens'
 import Tooltip from './tooltip'
@@ -52,6 +52,7 @@ export {
   Alert,
   Amount,
   Box,
+  BoxAlert,
   DisabledContent,
   DisabledPanel,
   DonationOverlay,
@@ -82,7 +83,6 @@ export {
   TableDonation,
   TableTransactions,
   Tip,
-  TipsMigrationAlert,
   ToggleTips,
   Tokens,
   Tooltip,

--- a/stories/assets/locale.ts
+++ b/stories/assets/locale.ts
@@ -13,6 +13,7 @@ const locale: Record<string, string> = {
   addFundsQR: 'Show QR Code',
   addFundsText: 'Be sure to use the address below that matches the type of cryto you own. It will be converted automatically to BAT by Uphold and appear as an increased balance in your Brave Rewards wallet. Please allow up to one hour for your wallet balance to update.',
   addFundsTitle: 'Send cryptocurrency from your external account to your Brave Rewards wallet.',
+  adsNotSupported: 'Sorry! Ads are not yet available in your region.',
   allowTip: 'Allow tips on',
   amount: 'Amount',
   and: 'and',

--- a/stories/features/rewards/settings/adsBox.tsx
+++ b/stories/features/rewards/settings/adsBox.tsx
@@ -5,7 +5,7 @@
 import * as React from 'react'
 
 // Components
-import { DisabledContent, Box } from '../../../../src/features/rewards'
+import { DisabledContent, Box, BoxAlert } from '../../../../src/features/rewards'
 
 // Utils
 import locale from './fakeLocale'
@@ -22,6 +22,12 @@ class AdsBox extends React.Component {
     )
   }
 
+  adsAlertChild = () => {
+    return (
+      <BoxAlert type={'ads'} />
+    )
+  }
+
   render () {
     return (
       <Box
@@ -29,6 +35,7 @@ class AdsBox extends React.Component {
         type={'ads'}
         description={locale.adsDesc}
         toggle={false}
+        attachedAlert={this.adsAlertChild()}
         disabledContent={this.adsDisabled()}
       />
     )

--- a/stories/features/rewards/settings/donationsBox.tsx
+++ b/stories/features/rewards/settings/donationsBox.tsx
@@ -5,7 +5,7 @@
 import * as React from 'react'
 
 // Components
-import { Box, TableDonation, Tokens, List, TipsMigrationAlert } from '../../../../src/features/rewards'
+import { Box, BoxAlert, TableDonation, Tokens, List } from '../../../../src/features/rewards'
 import { DetailRow as DonationDetailRow } from '../../../../src/features/rewards/tableDonation'
 import { Column, Grid, Checkbox, ControlWrapper } from '../../../../src/components'
 
@@ -98,7 +98,7 @@ class DonationsBox extends React.Component<{}, State> {
 
   donationAlertChild = () => {
     return (
-      <TipsMigrationAlert onReview={doNothing} />
+      <BoxAlert type={'tips'} onReview={doNothing} />
     )
   }
 


### PR DESCRIPTION
Related issue: https://github.com/brave/brave-browser/issues/2562

The tips alert component was too specific, now it is more general, and we can add a flavor for auto contribute now if needed.

<img width="625" alt="Screen Shot 2019-03-13 at 6 13 12 PM" src="https://user-images.githubusercontent.com/8732757/54325132-e125d800-45bd-11e9-8c44-fa4b274fbe94.png">

<img width="629" alt="Screen Shot 2019-03-13 at 6 13 17 PM" src="https://user-images.githubusercontent.com/8732757/54325135-e2570500-45bd-11e9-93c2-419238396b2d.png">

https://brave-ui-dmhift3yt.now.sh

## Changes

## Test plan


##### Link / storybook path to visual changes
- 
<!-- can be localhost storybook or `now` deployment -->

## Integration
- [ ] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [ ] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [ ] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
