### PR TITLE
Adding notification type for tips being processed

### DIFF
--- a/src/features/rewards/walletWrapper/index.tsx
+++ b/src/features/rewards/walletWrapper/index.tsx
@@ -81,7 +81,7 @@ export interface ActionWallet {
   action: () => void
 }
 
-export type NotificationType = 'ads' | 'backupWallet' | 'contribute' | 'grant' | 'insufficientFunds' | 'error' | ''
+export type NotificationType = 'ads' | 'backupWallet' | 'contribute' | 'grant' | 'insufficientFunds' | 'tipsProcessed' | 'error' | ''
 
 export interface Notification {
   id: string
@@ -315,6 +315,7 @@ export default class WalletWrapper extends React.PureComponent<Props, State> {
         icon = megaphoneIconUrl
         break
       case 'contribute':
+      case 'tipsProcessed':
         icon = loveIconUrl
         break
       case 'grant':
@@ -355,6 +356,9 @@ export default class WalletWrapper extends React.PureComponent<Props, State> {
         break
       case 'insufficientFunds':
         typeText = getLocale('insufficientFunds')
+        break
+      case 'tipsProcessed':
+        typeText = getLocale('contributionTips')
         break
       default:
         typeText = ''

--- a/stories/assets/locale.ts
+++ b/stories/assets/locale.ts
@@ -44,6 +44,7 @@ const locale: Record<string, string> = {
   contribute: 'Contribute',
   contributeAllocation: 'Auto-Contribute Allocation',
   contributeTooltip: 'Auto-Contribute Settings',
+  contributionTips: 'Contributions & Tips',
   copy: 'Copy',
   currentDonation: 'You’re currently donating {{currentDonation}} BAT to this site every month.',
   braveRewardsCreatingText: 'Creating wallet',


### PR DESCRIPTION
Related: https://github.com/brave/brave-browser/issues/3637
Core PR: https://github.com/brave/brave-core/pull/1959

<img width="388" alt="Screen Shot 2019-03-14 at 5 40 27 PM" src="https://user-images.githubusercontent.com/8732757/54400508-5ce85900-4680-11e9-831c-2a603f46fa62.png">

## Changes

## Test plan


##### Link / storybook path to visual changes
- 
<!-- can be localhost storybook or `now` deployment -->

## Integration
- [ ] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [ ] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [ ] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
