### PR TITLE
Fixing panel console error

### DIFF
--- a/src/features/rewards/rewardsButton/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/rewardsButton/__snapshots__/spec.tsx.snap
@@ -35,7 +35,6 @@ exports[`TipButton tests basic tests matches the snapshot 1`] = `
 >
   <span
     className="c1"
-    icon={false}
   />
 </button>
 `;

--- a/src/features/rewards/rewardsButton/index.tsx
+++ b/src/features/rewards/rewardsButton/index.tsx
@@ -32,7 +32,7 @@ export default class RewardsButton extends React.PureComponent<Props, {}> {
         onClick={onClick}
         data-test-id={testId}
       >
-        <StyledButtonText icon={!!icon}>
+        <StyledButtonText hasIcon={!!icon}>
           {text}
           {
             icon

--- a/src/features/rewards/rewardsButton/style.ts
+++ b/src/features/rewards/rewardsButton/style.ts
@@ -8,7 +8,7 @@ import styled, { css } from 'styled-components'
 
 interface StyleProps {
   type?: Type
-  icon?: boolean
+  hasIcon?: boolean
   disabled?: boolean
 }
 
@@ -78,7 +78,7 @@ export const StyledButtonText = styled<StyleProps, 'span'>('span')`
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.39px;
-  margin: ${p => p.icon ? '-3px auto 0px' : '0 auto'};
+  margin: ${p => p.hasIcon ? '-3px auto 0px' : '0 auto'};
 `
 
 export const StyledIcon = styled<{}, 'div'>('div')`

--- a/src/features/rewards/walletPanel/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/walletPanel/__snapshots__/spec.tsx.snap
@@ -180,7 +180,6 @@ exports[`WalletPanel tests basic tests matches the snapshot 1`] = `
       >
         <span
           className="c11"
-          icon={false}
         >
           MISSING: donateNow
         </span>

--- a/src/features/rewards/walletPanelDisabled/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/walletPanelDisabled/__snapshots__/spec.tsx.snap
@@ -211,7 +211,6 @@ exports[`DisabledPanel tests basic tests matches the snapshot 1`] = `
     >
       <span
         className="c8"
-        icon={true}
       >
         MISSING: enableRewards
         <div

--- a/src/features/rewards/welcomePage/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/welcomePage/__snapshots__/spec.tsx.snap
@@ -509,7 +509,6 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
             >
               <span
                 className="c18"
-                icon={false}
               >
                 MISSING: braveRewardsOptInText
               </span>
@@ -735,7 +734,6 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
               >
                 <span
                   className="c18"
-                  icon={false}
                 >
                   MISSING: readyToTakePartOptInText
                 </span>


### PR DESCRIPTION
Addresses: https://github.com/brave/brave-browser/issues/3904

The att name in this case just needed to be different than the component's prop name

## Test plan
By navigating to the wallet panel concept, confirm the console error in the above issue does not show.

##### Link / storybook path to visual changes
https://brave-ui-m1yk2rzha.now.sh

## Integration
- [ ] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [ ] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [ ] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
