### PR TITLE
Unverified publishers in panel can now have status refreshed

### DIFF
--- a/src/features/rewards/profile/index.tsx
+++ b/src/features/rewards/profile/index.tsx
@@ -15,10 +15,12 @@ import {
   StyledProviderWrap,
   StyledInlineVerified,
   StyledVerifiedText,
-  StyledInlineUnVerified
+  StyledInlineUnVerified,
+  StyledVerifiedCheckLink,
+  StyledRefresh
 } from './style'
 import { getLocale } from '../../../helpers'
-import { VerifiedIcon, UnVerifiedIcon } from '../../../components/icons'
+import { VerifiedIcon, UnVerifiedIcon, LoaderIcon } from '../../../components/icons'
 
 export type Provider = 'twitter' | 'youtube' | 'twitch'
 
@@ -31,6 +33,9 @@ export interface Props {
   verified?: boolean
   tableCell?: boolean
   showUnVerifiedHelpIcon?: boolean
+  refreshingPublisher?: boolean
+  publisherRefreshed?: boolean
+  onRefreshPublisher?: () => void
 }
 
 /*
@@ -66,7 +71,10 @@ export default class Profile extends React.PureComponent<Props, {}> {
       title,
       verified,
       tableCell,
-      showUnVerifiedHelpIcon
+      showUnVerifiedHelpIcon,
+      onRefreshPublisher,
+      refreshingPublisher,
+      publisherRefreshed
     } = this.props
 
     return (
@@ -109,6 +117,18 @@ export default class Profile extends React.PureComponent<Props, {}> {
               <StyledVerifiedText>
                 {getLocale('unVerifiedPublisher')}
               </StyledVerifiedText>
+              {
+                !publisherRefreshed ?
+                  refreshingPublisher ?
+                  <StyledRefresh>
+                    <LoaderIcon />
+                  </StyledRefresh>
+                  : <StyledVerifiedCheckLink onClick={onRefreshPublisher}>
+                    {getLocale('unVerifiedCheck')}
+                  </StyledVerifiedCheckLink>
+                :
+                null
+              }
             </StyledProviderWrap>
           ) : null}
         </StyledContent>

--- a/src/features/rewards/profile/style.ts
+++ b/src/features/rewards/profile/style.ts
@@ -3,6 +3,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import styled, { css } from 'styled-components'
+import palette from '../../../theme/colors'
 import { Props, Provider } from './index'
 
 const getOverflowRules = (provider?: Provider) => {
@@ -145,6 +146,24 @@ export const StyledVerifiedText = styled<{}, 'span'>('span')`
   font-weight: 400;
   letter-spacing: 0;
   margin-left: 4px;
+`
+
+export const StyledRefresh = styled<{}, 'span'>('span')`
+  color: ${palette.blue400};
+  line-height: 0;
+  height: 18px;
+  width: 18px;
+  vertical-align: bottom;
+  margin-left: auto;
+`
+
+export const StyledVerifiedCheckLink = styled<{}, 'span'>('span')`
+  font-size: 12px;
+  color: ${palette.blue400};
+  cursor: pointer;
+  text-decoration: none;
+  margin-left: auto;
+  z-index: 1;
 `
 
 export const StyledInlineVerified = styled<{}, 'span'>('span')`

--- a/src/features/rewards/walletPanel/index.tsx
+++ b/src/features/rewards/walletPanel/index.tsx
@@ -55,6 +55,9 @@ export interface Props {
   onToggleTips: () => void
   onAmountChange: () => void
   onIncludeInAuto: () => void
+  onRefreshPublisher?: () => void
+  refreshingPublisher?: boolean
+  publisherRefreshed?: boolean
   showUnVerified?: boolean
   moreLink?: string
   acEnabled?: boolean
@@ -75,6 +78,9 @@ export default class WalletPanel extends React.PureComponent<Props, {}> {
           showUnVerifiedHelpIcon={
             !this.props.isVerified && this.props.showUnVerified
           }
+          refreshingPublisher={this.props.refreshingPublisher}
+          onRefreshPublisher={this.props.onRefreshPublisher}
+          publisherRefreshed={this.props.publisherRefreshed}
         />
       </StyledProfileWrapper>
     )

--- a/src/features/rewards/walletSummary/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/walletSummary/__snapshots__/spec.tsx.snap
@@ -193,7 +193,7 @@ exports[`WalletSummary tests basic tests matches the snapshot 1`] = `
     <div
       className="c3"
     >
-      MISSING: monthMar
+      MISSING: monthApr
        
       2019
     </div>

--- a/stories/assets/locale.ts
+++ b/stories/assets/locale.ts
@@ -201,6 +201,7 @@ const locale: Record<string, string> = {
   turnOnRewardsTitle: 'Turn on Rewards',
   type: 'Type',
   uhOh: 'Uh oh…',
+  unVerifiedCheck: 'Check Again...',
   unVerifiedPublisher: 'Not yet verified',
   unVerifiedText: 'This creator has not yet signed up to receive contributions from Brave users.',
   unVerifiedTextMore: 'Learn more.',

--- a/stories/features/rewards/concepts.tsx
+++ b/stories/features/rewards/concepts.tsx
@@ -262,7 +262,7 @@ storiesOf('Feature Components/Rewards/Concepts/Desktop', module)
       </div>
     )
   })
-  .add('Wallet Panel', withState({ grant: defaultGrant, notification: grantNotification, showSummary: false, tipsEnabled: true, includeInAuto: true }, (store) => {
+  .add('Wallet Panel', withState({ grant: defaultGrant, notification: grantNotification, showSummary: false, tipsEnabled: true, includeInAuto: true, refreshingPublisher: false }, (store) => {
     const curveRgb = '233,235,255'
     const panelRgb = '249,251,252'
 
@@ -284,6 +284,10 @@ storiesOf('Feature Components/Rewards/Concepts/Desktop', module)
 
     const onIncludeInAuto = () => {
       store.set({ includeInAuto: !store.state.includeInAuto })
+    }
+
+    const onRefreshPublisher = () => {
+      store.set({ refreshingPublisher: !store.state.refreshingPublisher })
     }
 
     const onToggleTips = () => {
@@ -396,6 +400,8 @@ storiesOf('Feature Components/Rewards/Concepts/Desktop', module)
                 donationAction={doNothing}
                 onAmountChange={doNothing}
                 onIncludeInAuto={onIncludeInAuto}
+                refreshingPublisher={store.state.refreshingPublisher}
+                onRefreshPublisher={onRefreshPublisher}
               />
               <WalletSummary
                 compact={true}

--- a/stories/features/rewards/wallet.tsx
+++ b/stories/features/rewards/wallet.tsx
@@ -137,6 +137,7 @@ storiesOf('Feature Components/Rewards/Wallet/Desktop', module)
           onAmountChange={doNothing}
           onIncludeInAuto={doNothing}
           showUnVerified={boolean('Show unverified content', true)}
+          onRefreshPublisher={doNothing}
         />
       </div>
     )


### PR DESCRIPTION
Addresses https://github.com/brave/brave-browser/issues/3339

## Changes
Added 'Check again...' link to check for publisher's verified status

## Test plan
Open unverified wallet panel, verify 'Check again...' link
![image](https://user-images.githubusercontent.com/9574457/55397203-fc915c80-5545-11e9-99dc-ec043ef03386.png)


##### Link / storybook path to visual changes
- https://storybook-out.jasonrsadler.now.sh?path=/story/feature-components-rewards-wallet-desktop--panel
<!-- can be localhost storybook or `now` deployment -->

## Integration
- [ ] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [ ] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [ ] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
