### PR TITLE
Using overflow-y: auto for unverified notice

### DIFF
--- a/src/features/rewards/walletPanel/style.ts
+++ b/src/features/rewards/walletPanel/style.ts
@@ -98,7 +98,7 @@ export const StyledNoticeWrapper = styled<StyleProps, 'div'>('div')`
   border-radius: 4px;
   margin: 11px 0 10px;
   max-height: 84px;
-  overflow-y: scroll;
+  overflow-y: auto;
 `
 
 export const StyledNoticeLink = styled<StyleProps, 'a'>('a')`


### PR DESCRIPTION
Related: https://github.com/brave/brave-browser/issues/3930

You should not see the scrollbar in storybook on MacOS now if you have your preferences set to always show scroll bars.

## Changes

## Test plan


##### Link / storybook path to visual changes
https://brave-ui-n12kj8qp7.now.sh

## Integration
- [ ] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [ ] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [ ] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
