### PR TITLE
clock takes preferred locale, which can be used for https://github.com/brave/brave-browser/issues/1308

### DIFF
--- a/src/features/newTab/default/clock/index.tsx
+++ b/src/features/newTab/default/clock/index.tsx
@@ -16,14 +16,30 @@ export interface ClockState {
   date: Date
 }
 
-export class Clock extends React.PureComponent<{}, ClockState> {
-  constructor (props: {}) {
+interface PreferredLocale {
+  preferredLocale?: string | string[]
+}
+
+export class Clock extends React.PureComponent<PreferredLocale, ClockState> {
+  preferredLocale: string | string[]
+
+  constructor (props: PreferredLocale) {
     super(props)
+    /* We need to put the preferredLocale outside of state, to allow for
+       dateTimeFormat to be called for creating the original state */
+    this.preferredLocale = props.preferredLocale ? props.preferredLocale : []
     this.state = this.getClockState(new Date())
   }
 
   get dateTimeFormat (): any {
-    return new Intl.DateTimeFormat([], { hour: '2-digit', minute: '2-digit' })
+    try {
+      return new Intl.DateTimeFormat(this.preferredLocale, { hour: '2-digit', minute: '2-digit' })
+    } catch(e) {
+      /* in case the user has provided a preferred locale which is not a valid
+         language tag, Intl.DateTimeFormat throws a RangeError: in that case, go
+         for default locale */
+      return new Intl.DateTimeFormat([], { hour: '2-digit', minute: '2-digit' })
+    }
   }
 
   get formattedTime () {

--- a/src/features/newTab/default/clock/index.tsx
+++ b/src/features/newTab/default/clock/index.tsx
@@ -18,28 +18,38 @@ export interface ClockState {
 
 interface PreferredLocale {
   preferredLocale?: string | string[]
+  hour12?: boolean
 }
 
 export class Clock extends React.PureComponent<PreferredLocale, ClockState> {
   preferredLocale: string | string[]
+  hour12?: boolean
 
   constructor (props: PreferredLocale) {
     super(props)
     /* We need to put the preferredLocale outside of state, to allow for
        dateTimeFormat to be called for creating the original state */
     this.preferredLocale = props.preferredLocale ? props.preferredLocale : []
+    this.hour12 = props.hour12
     this.state = this.getClockState(new Date())
   }
 
   get dateTimeFormat (): any {
+    /*
     try {
       return new Intl.DateTimeFormat(this.preferredLocale, { hour: '2-digit', minute: '2-digit' })
     } catch(e) {
-      /* in case the user has provided a preferred locale which is not a valid
-         language tag, Intl.DateTimeFormat throws a RangeError: in that case, go
-         for default locale */
+      / in case the user has provided a preferred locale which is not a valid
+         language tag, Intl.DateTimeFormat throws a RangeError /
       return new Intl.DateTimeFormat([], { hour: '2-digit', minute: '2-digit' })
     }
+    */
+
+    if(this.hour12 === undefined) {
+      return new Intl.DateTimeFormat([], { hour: '2-digit', minute: '2-digit' })
+    }
+
+    return new Intl.DateTimeFormat([], { hour: '2-digit', minute: '2-digit', hour12: this.hour12 })
   }
 
   get formattedTime () {

--- a/src/features/newTab/default/clock/index.tsx
+++ b/src/features/newTab/default/clock/index.tsx
@@ -16,39 +16,20 @@ export interface ClockState {
   date: Date
 }
 
-interface PreferredLocale {
-  preferredLocale?: string | string[]
-  hour12?: boolean
+interface Preferences {
+  hour12: boolean
 }
 
-export class Clock extends React.PureComponent<PreferredLocale, ClockState> {
-  preferredLocale: string | string[]
-  hour12?: boolean
+export class Clock extends React.PureComponent<Preferences, ClockState> {
+  hour12: boolean
 
-  constructor (props: PreferredLocale) {
-    super(props)
-    /* We need to put the preferredLocale outside of state, to allow for
-       dateTimeFormat to be called for creating the original state */
-    this.preferredLocale = props.preferredLocale ? props.preferredLocale : []
-    this.hour12 = props.hour12
+  constructor (prefs: Preferences) {
+    super(prefs)
+    this.hour12 = prefs.hour12
     this.state = this.getClockState(new Date())
   }
 
   get dateTimeFormat (): any {
-    /*
-    try {
-      return new Intl.DateTimeFormat(this.preferredLocale, { hour: '2-digit', minute: '2-digit' })
-    } catch(e) {
-      / in case the user has provided a preferred locale which is not a valid
-         language tag, Intl.DateTimeFormat throws a RangeError /
-      return new Intl.DateTimeFormat([], { hour: '2-digit', minute: '2-digit' })
-    }
-    */
-
-    if(this.hour12 === undefined) {
-      return new Intl.DateTimeFormat([], { hour: '2-digit', minute: '2-digit' })
-    }
-
     return new Intl.DateTimeFormat([], { hour: '2-digit', minute: '2-digit', hour12: this.hour12 })
   }
 


### PR DESCRIPTION
## Changes
Allows the clock to take a preferred locale for showing the time, and not just depend on the system locale, which can be used for https://github.com/brave/brave-browser/issues/1308

> Will you create brave-core PR to update to this commit after it is merged?

 will take place in the PR for the issue mentioned above.

## Test plan


##### Link / storybook path to visual changes
- 
<!-- can be localhost storybook or `now` deployment -->

## Integration
- [X] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [X] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [X] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
