### PR TITLE
Fix dropdown colors for Shields in Windows

### DIFF
--- a/src/features/rewards/walletSummary/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/walletSummary/__snapshots__/spec.tsx.snap
@@ -185,7 +185,7 @@ exports[`WalletSummary tests basic tests matches the snapshot 1`] = `
     <div
       className="c3"
     >
-      MISSING: monthApr
+      MISSING: monthMay
        
       2019
     </div>

--- a/src/features/shields/select/index.ts
+++ b/src/features/shields/select/index.ts
@@ -41,7 +41,7 @@ export const SelectBox = styled<SelectBoxProps, 'select'>('select')`
   cursor: pointer;
 
   > option {
-    /* DO NOT MODIFY: this is for the dropdown only and has effect only on Windows */
+    /* see https://github.com/brave/brave-browser/issues/4213 for info */
     color: ${palette.black};
   }
 

--- a/src/features/shields/select/index.ts
+++ b/src/features/shields/select/index.ts
@@ -41,7 +41,8 @@ export const SelectBox = styled<SelectBoxProps, 'select'>('select')`
   cursor: pointer;
 
   > option {
-    color: ${palette.white};
+    /* DO NOT MODIFY: this is for the dropdown only and has effect only on Windows */
+    color: ${palette.black};
   }
 
   ${(p: SelectBoxProps) => p.disabled


### PR DESCRIPTION
Test Plan:

Ensure dropdowns on Shields have visible text across platforms

Now link: https://brave-ui-e45cj4qm1.now.sh