### PR TITLE
sanitize social media links in tipping banner

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,8 @@
       "!src/**/index.ts"
     ],
     "testMatch": [
-      "<rootDir>/src/**/spec.tsx"
+      "<rootDir>/src/**/spec.tsx",
+      "<rootDir>/src/*.test.ts"
     ],
     "testPathIgnorePatterns": [
       "<rootDir>/node_modules/"

--- a/src/features/rewards/siteBanner/index.tsx
+++ b/src/features/rewards/siteBanner/index.tsx
@@ -36,7 +36,7 @@ import {
 
 import Donate from '../donate/index'
 import Checkbox from '../../../components/formControls/checkbox/index'
-import { getLocale } from '../../../helpers'
+import { getLocale, normalizeSocialUrl } from '../../../helpers'
 import {
   CloseCircleOIcon,
   TwitterColorIcon,
@@ -121,6 +121,10 @@ export default class SiteBanner extends React.PureComponent<Props, State> {
 
     const self = this
     return social.map((item: Social) => {
+      const href = normalizeSocialUrl(item.type, item.url)
+      if (!href) {
+        return null
+      }
       const logo = self.getSocialData(item)
       return (
         <StyledSocialItem

--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { normalizeSocialUrl } from './helpers'
+
+test('normalize with null inputs', () => {
+  expect(normalizeSocialUrl()).toBe('')
+})
+
+test('normalize with null second input', () => {
+  expect(normalizeSocialUrl('twitter', null)).toBe('')
+})
+
+test('normalize with invalid type', () => {
+  expect(normalizeSocialUrl('soundcloud', 'https://soundcloud.com/')).toBe('')
+})
+
+test('normalize with invalid URLs', () => {
+  expect(normalizeSocialUrl('twitch', 'https://twitch.com/')).toBe('')
+  expect(normalizeSocialUrl('twitch', 'https://twitchxtv/')).toBe('')
+  expect(normalizeSocialUrl('twitter', 'https://www.twitch.com/')).toBe('')
+  expect(normalizeSocialUrl('twitter', 'ahttps://www.twitter.com/')).toBe('')
+  expect(normalizeSocialUrl('twitter', 'https://www.twitter.com')).toBe('')
+  expect(normalizeSocialUrl('youtube', 'http://youtube.com/')).toBe('')
+  expect(normalizeSocialUrl('youtube', 'youtube.com')).toBe('')
+  expect(normalizeSocialUrl('youtube', 'www.youtube.com')).toBe('')
+  expect(normalizeSocialUrl('youtube', 'wwwyoutube.com/')).toBe('')
+  expect(normalizeSocialUrl('twitch', 'https://youtube.com/')).toBe('')
+})
+
+test('normalize with valid URLs', () => {
+  expect(normalizeSocialUrl('twitch', 'https://twitch.tv/'))
+    .toBe('https://twitch.tv/')
+  expect(normalizeSocialUrl('twitch', 'https://www.twitch.tv/test'))
+    .toBe('https://www.twitch.tv/test')
+  expect(normalizeSocialUrl('youtube', 'www.youtube.com/foo.bar'))
+    .toBe('https://www.youtube.com/foo.bar')
+  expect(normalizeSocialUrl('youtube', 'youtube.com/'))
+    .toBe('https://youtube.com/')
+  expect(normalizeSocialUrl('twitter', 'twitter.com/omg/omg/?test#hashtag'))
+    .toBe('https://twitter.com/omg/omg/?test#hashtag')
+  expect(normalizeSocialUrl('twitter', 'https://www.twitter.com/?test#hashtag'))
+    .toBe('https://www.twitter.com/?test#hashtag')
+})

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -72,3 +72,27 @@ export const getLocale = (key: string, replacements?: Replacements) => {
   }
   return returnVal
 }
+
+const socialRegexes = {
+  twitter: /^(https:\/\/)?(www\.)?twitter\.com\//,
+  youtube: /^(https:\/\/)?(www\.)?youtube\.com\//,
+  twitch: /^(https:\/\/)?(www\.)?twitch\.tv\//
+}
+
+/**
+ * Normalizes a social media URL from the publishers database. Returns empty
+ * if input is not a valid social URL.
+ * @param {string} type - social media type
+ * @param {string} input - input social url
+ * @returns {string} - the normalized url
+ */
+export const normalizeSocialUrl = (type: string, input: string) => {
+  const regex = socialRegexes[type]
+  if (regex && regex.test(input)) {
+    if (input.startsWith('https://')) {
+      return input
+    }
+    return `https://${input}`
+  }
+  return ''
+}


### PR DESCRIPTION
fix #466

## Changes

## Test plan
1. go to https://www.nate.blue/ (it may not load; that's fine)
2. click rewards icon to send a tip
3. no social icons should appear


##### Link / storybook path to visual changes
- No visual changes
<!-- can be localhost storybook or `now` deployment -->

## Integration
- [ ] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [ ] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [ ] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
