### PR TITLE
Service text ready

### DIFF
--- a/src/features/rewards/welcomePage/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/welcomePage/__snapshots__/spec.tsx.snap
@@ -816,7 +816,7 @@ exports[`WelcomePage tests basic tests matches the snapshot 1`] = `
               <span
                 className="c49"
               >
-                MISSING: serviceTextWelcome
+                MISSING: serviceTextReady
                  
                 <a
                   className="c50"

--- a/src/features/rewards/welcomePage/index.tsx
+++ b/src/features/rewards/welcomePage/index.tsx
@@ -203,7 +203,7 @@ class WelcomePage extends React.PureComponent<Props, {}> {
           !this.isTouchScreen
           ? <StyledTOSWrapper>
               <StyledServiceText>
-                {getLocale('serviceTextWelcome')} <StyledServiceLink onClick={onTOSClick}>{getLocale('termsOfService')}</StyledServiceLink> {getLocale('and')} <StyledServiceLink onClick={onPrivacyClick}>{getLocale('privacyPolicy')}</StyledServiceLink>.
+                {getLocale('serviceTextReady')} <StyledServiceLink onClick={onTOSClick}>{getLocale('termsOfService')}</StyledServiceLink> {getLocale('and')} <StyledServiceLink onClick={onPrivacyClick}>{getLocale('privacyPolicy')}</StyledServiceLink>.
               </StyledServiceText>
             </StyledTOSWrapper>
           : null

--- a/stories/assets/locale.ts
+++ b/stories/assets/locale.ts
@@ -185,6 +185,7 @@ const locale: Record<string, string> = {
   serviceTextToggle: 'By turning on Brave Rewards, you indicate that you have read and agree to the',
   serviceTextPanelWelcome: 'By clicking ‘Join Rewards’, you indicate that you have read and agree to the',
   serviceTextWelcome: 'By clicking ‘Yes, I\'m in!’, you indicate that you have read and agree to the',
+  serviceTextReady: 'By clicking ‘Yes, I\'m Ready!’, you indicate that you have read and agree to the',
   settings: 'Settings',
   site: 'site',
   siteBannerNoticeNote: 'NOTE:',


### PR DESCRIPTION
Related: https://github.com/brave/brave-browser/issues/4489

## Changes
Changed service text to match the text on button.
## Test plan


##### Link / storybook path to visual changes
https://brave-ui-mfe6xww2v.now.sh
<!-- can be localhost storybook or `now` deployment -->

## Integration
- [x] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [x] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [x] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [x] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
