### PR TITLE
Remove css overrides for Card component

### DIFF
--- a/src/components/layout/card/__snapshots__/spec.tsx.snap
+++ b/src/components/layout/card/__snapshots__/spec.tsx.snap
@@ -6,17 +6,25 @@ exports[`card tests basic tests matches the snapshot 1`] = `
   width: 100%;
   min-height: auto;
   margin: 0;
-  padding: 30px 36px;
   background-color: #fff;
   border-radius: 4px;
   box-shadow: 0 2px 4px rgba(0,0,0,.15);
   font-size: inherit;
+  font-family: Muli,sans-serif;
   box-sizing: border-box;
   position: relative;
+}
+
+.c1 {
+  padding: 32px;
 }
 
 <div
   className="c0"
   data-test-id="testCard"
-/>
+>
+  <div
+    className="c1"
+  />
+</div>
 `;

--- a/src/components/layout/card/index.tsx
+++ b/src/components/layout/card/index.tsx
@@ -4,13 +4,23 @@
 
 import * as React from 'react'
 
-import { StyledCard } from './style'
+import * as Styled from './style'
 
+export type Emphasis = '50' | '60' // a (small) scale
 export interface CardProps {
   testId?: string
   children?: React.ReactNode
   className?: string
+  useDefaultContentPadding?: boolean
+  emphasis?: Emphasis
 }
+
+interface PropsWithDefaults {
+  useDefaultContentPadding: boolean
+  emphasis: Emphasis
+}
+
+type ActualProps = CardProps & PropsWithDefaults
 
 /**
  * Card Component
@@ -18,12 +28,29 @@ export interface CardProps {
  * @prop {string} testId - the test id to be used for testing
  * @prop {React.ReactNode} children - the child components/elements to be included
  */
-export default class Card extends React.PureComponent<CardProps, {}> {
-  render () {
-    const { testId, children, className } = this.props
+export default class Card extends React.Component<ActualProps, {}> {
+  static defaultProps = {
+    useDefaultContentPadding: true,
+    emphasis: '50'
+  }
 
+  render () {
+    const {
+      testId,
+      children
+    } = this.props
+
+    const styleProps = {
+      className: this.props.className,
+      useDefaultContentPadding: this.props.useDefaultContentPadding,
+      emphasis: this.props.emphasis
+    }
     return (
-      <StyledCard className={className} data-test-id={testId}>{children}</StyledCard>
+      <Styled.Card data-test-id={testId} {...styleProps}>
+        <Styled.Content {...styleProps}>
+          {children}
+        </Styled.Content>
+      </Styled.Card>
     )
   }
 }

--- a/src/components/layout/card/spec.tsx
+++ b/src/components/layout/card/spec.tsx
@@ -2,11 +2,14 @@
 import * as React from 'react'
 import { shallow } from 'enzyme'
 import { create } from 'react-test-renderer'
+import { TestThemeProvider } from '../../../theme'
 import Card from './index'
 
 describe('card tests', () => {
   const baseComponent = (props?: object) => (
-    <Card testId='testCard' {...props} />
+    <TestThemeProvider>
+      <Card testId='testCard' {...props} />
+    </TestThemeProvider>
   )
   describe('basic tests', () => {
     it('matches the snapshot', () => {
@@ -16,9 +19,10 @@ describe('card tests', () => {
     })
 
     it('renders the component', () => {
-      const wrapper = shallow(baseComponent({testId: 'toughCard'}))
-      const assertion = wrapper.props()['data-test-id']
-      expect(assertion).toBe('toughCard')
+      const testId = 'toughCard'
+      const wrapper = shallow(baseComponent({testId}))
+      const assertion = wrapper.find({['data-test-id']: testId})
+      expect(assertion).toBeTruthy()
     })
   })
 })

--- a/src/components/layout/card/style.ts
+++ b/src/components/layout/card/style.ts
@@ -2,19 +2,37 @@
  * License. v. 2.0. If a copy of the MPL was not distributed with this file.
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import styled from 'styled-components'
-import { CardProps } from './index'
+import styled from '../../../theme'
+import { Emphasis } from './'
 
-export const StyledCard = styled<CardProps, 'div'>('div')`
+interface StyledCardProps {
+  useDefaultContentPadding: boolean
+  emphasis: Emphasis
+}
+
+function getShadowOpacity (emphasis: Emphasis) {
+  switch (emphasis) {
+    case '60':
+      return '.2'
+    default:
+      return '.15'
+  }
+}
+
+export const Card = styled<StyledCardProps, 'div'>('div')`
   max-width: 100%;
   width: 100%;
   min-height: auto;
   margin: 0;
-  padding: 30px 36px;
   background-color: #fff;
   border-radius: 4px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, .15);
+  box-shadow: ${p => `0 2px 4px rgba(0, 0, 0, ${getShadowOpacity(p.emphasis)})`};
   font-size: inherit;
+  font-family: ${p => p.theme.fontFamily.body};
   box-sizing: border-box;
   position: relative;
+`
+
+export const Content = styled<StyledCardProps, 'div'>('div')`
+  padding: ${p => p.useDefaultContentPadding ? '32px' : undefined};
 `

--- a/src/features/rewards/box/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/box/__snapshots__/spec.tsx.snap
@@ -6,13 +6,17 @@ exports[`Box tests basic tests matches the snapshot 1`] = `
   width: 100%;
   min-height: auto;
   margin: 0;
-  padding: 30px 36px;
   background-color: #fff;
   border-radius: 4px;
-  box-shadow: 0 2px 4px rgba(0,0,0,.15);
+  box-shadow: 0 2px 4px rgba(0,0,0,.2);
   font-size: inherit;
+  font-family: Muli,sans-serif;
   box-sizing: border-box;
   position: relative;
+}
+
+.c3 {
+  padding: 32px;
 }
 
 .c0 {
@@ -21,13 +25,10 @@ exports[`Box tests basic tests matches the snapshot 1`] = `
 }
 
 .c1 {
-  font-family: Muli,sans-serif;
-  padding: 32px;
-  box-shadow: 0 2px 4px rgba(0,0,0,.2);
   font-size: 14px;
 }
 
-.c3 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -42,7 +43,7 @@ exports[`Box tests basic tests matches the snapshot 1`] = `
   justify-content: center;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -52,7 +53,7 @@ exports[`Box tests basic tests matches the snapshot 1`] = `
   flex-direction: column;
 }
 
-.c6 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -63,7 +64,7 @@ exports[`Box tests basic tests matches the snapshot 1`] = `
   color: #4b4c5c;
 }
 
-.c8 {
+.c9 {
   width: 100%;
   font-size: 15px;
   color: #5e6175;
@@ -71,7 +72,7 @@ exports[`Box tests basic tests matches the snapshot 1`] = `
   line-height: 1.7;
 }
 
-.c9 {
+.c10 {
   -webkit-flex-basis: 100%;
   -ms-flex-preferred-size: 100%;
   flex-basis: 100%;
@@ -82,13 +83,13 @@ exports[`Box tests basic tests matches the snapshot 1`] = `
   margin-top: 25px;
 }
 
-.c10 {
+.c11 {
   background: #fff;
   display: none;
   width: 100%;
 }
 
-.c11 {
+.c12 {
   display: none;
   position: absolute;
   right: 24px;
@@ -102,7 +103,7 @@ exports[`Box tests basic tests matches the snapshot 1`] = `
   color: #84889c;
 }
 
-.c5 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -118,7 +119,7 @@ exports[`Box tests basic tests matches the snapshot 1`] = `
   height: 100%;
 }
 
-.c13 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -126,7 +127,7 @@ exports[`Box tests basic tests matches the snapshot 1`] = `
   margin: 0 0 24px;
 }
 
-.c7 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -137,7 +138,7 @@ exports[`Box tests basic tests matches the snapshot 1`] = `
   align-items: center;
 }
 
-.c14 {
+.c15 {
   font-size: 20px;
   font-weight: 600;
   font-family: Poppins,sans-serif;
@@ -152,7 +153,7 @@ exports[`Box tests basic tests matches the snapshot 1`] = `
   align-items: center;
 }
 
-.c12 {
+.c13 {
   width: 100%;
   height: 100%;
   fill: currentColor;
@@ -166,58 +167,62 @@ exports[`Box tests basic tests matches the snapshot 1`] = `
     data-test-id="box"
   >
     <div
-      className="c3"
+      className="c1 c3"
     >
       <div
         className="c4"
-        open={true}
       >
         <div
           className="c5"
+          open={true}
         >
           <div
             className="c6"
           >
-            test
+            <div
+              className="c7"
+            >
+              test
+            </div>
+            <div
+              className="c8"
+            />
           </div>
           <div
-            className="c7"
+            className="c9"
+          />
+          <div
+            className="c10"
           />
         </div>
         <div
-          className="c8"
-        />
-        <div
-          className="c9"
-        />
-      </div>
-      <div
-        className="c10"
-      >
-        <button
           className="c11"
         >
-          <svg
-            aria-hidden="true"
+          <button
             className="c12"
-            focusable="false"
-            viewBox="0 0 32 32"
           >
-            <path
-              d="M16 3a13 13 0 1 0 13 13A13 13 0 0 0 16 3zm0 24a11 11 0 1 1 11-11 11 11 0 0 1-11 11z"
-            />
-            <path
-              d="M20.71 11.29a1 1 0 0 0-1.42 0L16 14.59l-3.29-3.3a1 1 0 0 0-1.42 1.42l3.3 3.29-3.3 3.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l3.29-3.3 3.29 3.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42L17.41 16l3.3-3.29a1 1 0 0 0 0-1.42z"
-            />
-          </svg>
-        </button>
-        <div
-          className="c13"
-        >
+            <svg
+              aria-hidden="true"
+              className="c13"
+              focusable="false"
+              viewBox="0 0 32 32"
+            >
+              <path
+                d="M16 3a13 13 0 1 0 13 13A13 13 0 0 0 16 3zm0 24a11 11 0 1 1 11-11 11 11 0 0 1-11 11z"
+              />
+              <path
+                d="M20.71 11.29a1 1 0 0 0-1.42 0L16 14.59l-3.29-3.3a1 1 0 0 0-1.42 1.42l3.3 3.29-3.3 3.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l3.29-3.3 3.29 3.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42L17.41 16l3.3-3.29a1 1 0 0 0 0-1.42z"
+              />
+            </svg>
+          </button>
           <div
             className="c14"
           >
-            test MISSING: settings
+            <div
+              className="c15"
+            >
+              test MISSING: settings
+            </div>
           </div>
         </div>
       </div>

--- a/src/features/rewards/box/index.tsx
+++ b/src/features/rewards/box/index.tsx
@@ -74,7 +74,6 @@ export default class Box extends React.PureComponent<Props, {}> {
       <StyledWrapper>
         <StyledCard
           testId={id}
-          hasAlert={!!attachedAlert}
         >
           <StyledFlip>
             <StyledContentWrapper open={!settingsOpened}>

--- a/src/features/rewards/box/style.tsx
+++ b/src/features/rewards/box/style.tsx
@@ -2,20 +2,16 @@
  * License. v. 2.0. If a copy of the MPL was not distributed with this file.
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import * as React from 'react'
 import styled from '../../../theme'
 import { Type } from './index'
 import Card, { CardProps } from '../../../components/layout/card'
-import { ComponentType } from 'react'
 
 interface StyleProps {
   open?: boolean
   float?: string
   checked?: boolean
   type?: Type
-}
-
-interface CardStyleProps extends CardProps {
-  hasAlert?: boolean
 }
 
 const colors: Record<Type, string> = {
@@ -29,10 +25,10 @@ export const StyledWrapper = styled<StyleProps, 'div'>('div')`
   margin: 0 0 24px;
 `
 
-export const StyledCard = styled(Card as ComponentType<CardStyleProps>)`
-  font-family: ${p => p.theme.fontFamily.body};
-  padding: 32px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, .2);
+const CustomCard: React.FC<CardProps> = (props) =>
+  <Card emphasis={'60'} {...props} />
+
+export const StyledCard = styled(CustomCard)`
   font-size: 14px;
 `
 

--- a/src/features/rewards/disabledBox/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/disabledBox/__snapshots__/spec.tsx.snap
@@ -6,13 +6,17 @@ exports[`DisabledBox tests basic tests matches the snapshot 1`] = `
   width: 100%;
   min-height: auto;
   margin: 0;
-  padding: 30px 36px;
   background-color: #fff;
   border-radius: 4px;
   box-shadow: 0 2px 4px rgba(0,0,0,.15);
   font-size: inherit;
+  font-family: Muli,sans-serif;
   box-sizing: border-box;
   position: relative;
+}
+
+.c3 {
+  padding: 32px;
 }
 
 .c0 {
@@ -25,7 +29,7 @@ exports[`DisabledBox tests basic tests matches the snapshot 1`] = `
   font-family: Poppins,sans-serif;
 }
 
-.c3 {
+.c4 {
   width: 541px;
   color: #4C54D2;
   font-size: 22px;
@@ -38,7 +42,7 @@ exports[`DisabledBox tests basic tests matches the snapshot 1`] = `
   padding-bottom: 5px;
 }
 
-.c4 {
+.c5 {
   color: #84889c;
   font-size: 16px;
   font-weight: normal;
@@ -51,7 +55,7 @@ exports[`DisabledBox tests basic tests matches the snapshot 1`] = `
   font-family: Muli,sans-serif;
 }
 
-.c4:first-of-type {
+.c5:first-of-type {
   padding-bottom: 10px;
 }
 
@@ -61,26 +65,30 @@ exports[`DisabledBox tests basic tests matches the snapshot 1`] = `
   <div
     className="c1 c2"
   >
-    <span
-      className="c3"
+    <div
+      className="c1 c3"
     >
-      MISSING: whyBraveRewards
-    </span>
-    <p
-      className="c4"
-    >
-      MISSING: rewardsOffText5
-    </p>
-    <span
-      className="c3"
-    >
-      MISSING: rewardsOffText3
-    </span>
-    <p
-      className="c4"
-    >
-      MISSING: rewardsOffText4
-    </p>
+      <span
+        className="c4"
+      >
+        MISSING: whyBraveRewards
+      </span>
+      <p
+        className="c5"
+      >
+        MISSING: rewardsOffText5
+      </p>
+      <span
+        className="c4"
+      >
+        MISSING: rewardsOffText3
+      </span>
+      <p
+        className="c5"
+      >
+        MISSING: rewardsOffText4
+      </p>
+    </div>
   </div>
 </div>
 `;

--- a/src/features/rewards/disabledBox/style.ts
+++ b/src/features/rewards/disabledBox/style.ts
@@ -3,8 +3,9 @@
 * You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-import styled from 'styled-components'
-import Card from '../../../components/layout/card'
+import { ComponentType } from 'react'
+import styled from '../../../theme'
+import Card, { CardProps } from '../../../components/layout/card'
 import palette from '../../../theme/colors'
 
 export const StyledWrapper = styled<{}, 'div'>('div')`
@@ -13,7 +14,7 @@ export const StyledWrapper = styled<{}, 'div'>('div')`
   margin-bottom: 28px;
 `
 
-export const StyledCard = styled(Card)`
+export const StyledCard = styled<CardProps>(Card as ComponentType<CardProps>)`
   font-family: Poppins, sans-serif;
 `
 

--- a/src/features/rewards/mobile/boxMobile/__snapshots__/spec.tsx.snap
+++ b/src/features/rewards/mobile/boxMobile/__snapshots__/spec.tsx.snap
@@ -6,19 +6,17 @@ exports[`Box tests basic tests matches the snapshot 1`] = `
   width: 100%;
   min-height: auto;
   margin: 0;
-  padding: 30px 36px;
   background-color: #fff;
   border-radius: 4px;
   box-shadow: 0 2px 4px rgba(0,0,0,.15);
   font-size: inherit;
+  font-family: Muli,sans-serif;
   box-sizing: border-box;
   position: relative;
 }
 
 .c0 {
   margin-bottom: 12px;
-  padding: 0;
-  font-family: Muli,sans-serif;
 }
 
 .c2 {
@@ -105,37 +103,41 @@ exports[`Box tests basic tests matches the snapshot 1`] = `
   data-test-id="box"
 >
   <div
-    className="c2"
+    className="c0 "
   >
     <div
-      className="c3"
-      open={true}
+      className="c2"
     >
       <div
-        className="c4"
+        className="c3"
+        open={true}
       >
         <div
-          className="c5"
+          className="c4"
         >
           <div
-            className="c6"
+            className="c5"
           >
-            test
+            <div
+              className="c6"
+            >
+              test
+            </div>
           </div>
+          <div
+            className="c7"
+          />
         </div>
         <div
-          className="c7"
+          className="c8"
         />
-      </div>
-      <div
-        className="c8"
-      />
-      <div
-        className="c9"
-      >
         <div
-          className="c10"
-        />
+          className="c9"
+        >
+          <div
+            className="c10"
+          />
+        </div>
       </div>
     </div>
   </div>

--- a/src/features/rewards/mobile/boxMobile/index.tsx
+++ b/src/features/rewards/mobile/boxMobile/index.tsx
@@ -290,7 +290,6 @@ export default class BoxMobile extends React.PureComponent<Props, State> {
     return (
       <StyledCard
         testId={id}
-        checked={checked}
       >
         <StyledFlip>
           <StyledContentWrapper open={!this.state.settings}>

--- a/src/features/rewards/mobile/boxMobile/style.tsx
+++ b/src/features/rewards/mobile/boxMobile/style.tsx
@@ -2,10 +2,10 @@
  * License. v. 2.0. If a copy of the MPL was not distributed with this file.
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import * as React from 'react'
 import styled, { css } from '../../../../theme'
 import { Type } from './index'
 import Card, { CardProps } from '../../../../components/layout/card'
-import { ComponentType } from 'react'
 
 interface StyleProps {
   open?: boolean
@@ -14,10 +14,6 @@ interface StyleProps {
   enabled?: boolean
   detailView?: boolean
   contentShown?: boolean
-}
-
-interface CardStyleProps extends CardProps {
-  checked?: boolean
 }
 
 const colors: Record<Type, string> = {
@@ -39,10 +35,11 @@ const getFixedStyling = (detailView?: boolean) => {
   `
 }
 
-export const StyledCard = styled(Card as ComponentType<CardStyleProps>)`
+const CustomCard: React.FC<CardProps> = (props) =>
+  <Card useDefaultContentPadding={false} {...props} />
+
+export const StyledCard = styled(CustomCard)`
   margin-bottom: 12px;
-  padding: 0;
-  font-family: ${p => p.theme.fontFamily.body};
 `
 
 export const StyledFlip = styled<{}, 'div'>('div')`

--- a/src/features/sync/index.ts
+++ b/src/features/sync/index.ts
@@ -8,6 +8,7 @@ export {
   EnabledContent,
   Main,
   SyncCard,
+  SyncCardContent,
   TableRowId,
   TableRowDevice,
   TableRowRemove,

--- a/src/features/sync/misc/index.tsx
+++ b/src/features/sync/misc/index.tsx
@@ -2,8 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import * as React from 'react'
 import styled from '../../../theme'
 import { Card } from '../../../components'
+import { CardProps } from '../../../components/layout/card'
 
 export const DisabledContent = styled<{}, 'div'>('div')`
   display: flex;
@@ -27,7 +29,10 @@ export const Main = styled<{}, 'main'>('main')`
   margin: auto;
 `
 
-export const SyncCard = styled(Card)`
+export const SyncCard: React.FC<CardProps> = (props) =>
+  <Card useDefaultContentPadding={false} {...props} />
+
+export const SyncCardContent = styled('div')`
   padding: 60px 80px;
 `
 

--- a/src/features/welcome/wrapper/index.ts
+++ b/src/features/welcome/wrapper/index.ts
@@ -3,7 +3,6 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import styled, { css, keyframes } from 'styled-components'
-import { Card } from '../../../index'
 
 const fadeIn = keyframes`
   from {
@@ -92,7 +91,7 @@ export const Page = styled<{}, 'div'>('div')`
   justify-content: center;
 `
 
-export const Panel = styled(Card)`
+export const Panel = styled('div')`
   user-select: none;
   /* animation start state must be the same as "from" keyframe */
   opacity: 0;
@@ -103,17 +102,21 @@ export const Panel = styled(Card)`
   animation-timing-function: ease-out;
   animation-fill-mode: forwards;
   /* end of animation stuff */
+  box-sizing: border-box;
   position: relative;
   overflow: hidden;
+  margin: 0;
   background-color: rgba(255,255,255,0.99);
   border-radius: 20px;
   box-shadow: 0 6px 12px 0 rgba(39, 46, 64, 0.2);
   max-width: 600px;
+  width: 100%;
   min-height: 540px;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   padding: 0;
+  font-size: inherit;
 `
 
 export const SlideContent = styled<{}, 'div'>('div')`

--- a/stories/features/sync/disabledContent.tsx
+++ b/stories/features/sync/disabledContent.tsx
@@ -12,6 +12,7 @@ import {
   DisabledContent,
   Main,
   SyncCard,
+  SyncCardContent,
   Title,
   DisabledContentButtonGrid,
   TableGrid,
@@ -71,27 +72,29 @@ export default class SyncDisabledContent extends React.PureComponent<{}, State> 
               : null
           }
           <SyncCard>
-            <TableGrid isDeviceTable={false}>
-              <SyncStartIcon />
-              <div>
-                <Title level={2}>{getLocale('syncTitle')}</Title>
-                <Paragraph>{getLocale('syncDescription')}</Paragraph>
-                <DisabledContentButtonGrid>
-                  <Button
-                    level='primary'
-                    type='accent'
-                    onClick={this.onClickNewSyncChainButton}
-                    text={getLocale('startSyncChain')}
-                  />
-                  <Button
-                    level='secondary'
-                    type='accent'
-                    onClick={this.onClickEnterSyncChainCodeButton}
-                    text={getLocale('enterSyncChainCode')}
-                  />
-                </DisabledContentButtonGrid>
-              </div>
-            </TableGrid>
+            <SyncCardContent>
+              <TableGrid isDeviceTable={false}>
+                <SyncStartIcon />
+                <div>
+                  <Title level={2}>{getLocale('syncTitle')}</Title>
+                  <Paragraph>{getLocale('syncDescription')}</Paragraph>
+                  <DisabledContentButtonGrid>
+                    <Button
+                      level='primary'
+                      type='accent'
+                      onClick={this.onClickNewSyncChainButton}
+                      text={getLocale('startSyncChain')}
+                    />
+                    <Button
+                      level='secondary'
+                      type='accent'
+                      onClick={this.onClickEnterSyncChainCodeButton}
+                      text={getLocale('enterSyncChainCode')}
+                    />
+                  </DisabledContentButtonGrid>
+                </div>
+              </TableGrid>
+            </SyncCardContent>
           </SyncCard>
         </Main>
       </DisabledContent>

--- a/stories/features/sync/enabledContent.tsx
+++ b/stories/features/sync/enabledContent.tsx
@@ -15,6 +15,7 @@ import {
   EnabledContent,
   Main,
   SyncCard,
+  SyncCardContent,
   Title,
   Paragraph,
   SectionBlock,
@@ -197,44 +198,46 @@ export default class SyncEnabledContent extends React.PureComponent<{}, State> {
             />
           ) : null}
           <SyncCard>
-            <Title level={2}>{getLocale('braveSync')}</Title>
-            <Paragraph>{getLocale('syncChainDevices')}</Paragraph>
-            <SectionBlock>
-              <TableGrid isDeviceTable={true}>
-                <Table header={this.deviceHeader} rows={this.deviceRows} />
-                <TableButtonGrid>
-                  <br />
-                  <Button
-                    level='secondary'
-                    type='accent'
-                    size='medium'
-                    text={getLocale('viewSyncCode')}
-                    onClick={this.onClickViewSyncCodeButton}
-                  />
-                  <Button
-                    level='primary'
-                    type='accent'
-                    size='medium'
-                    text={getLocale('addDevice')}
-                    onClick={this.onClickAddDeviceButton}
-                  />
-                </TableButtonGrid>
-              </TableGrid>
-            </SectionBlock>
-            <Title level={2}>{getLocale('syncSettings')}</Title>
-            <Paragraph>{getLocale('syncSettingsDescription')}</Paragraph>
-            <SectionBlock>
-              <Table header={this.settingsHeader} rows={this.settingsRows} />
-            </SectionBlock>
-            <SectionBlock>
-              <Button
-                level='primary'
-                type='accent'
-                size='medium'
-                text={getLocale('leaveSyncChain')}
-                onClick={this.onClickResetSyncButton}
-              />
-            </SectionBlock>
+            <SyncCardContent>
+              <Title level={2}>{getLocale('braveSync')}</Title>
+              <Paragraph>{getLocale('syncChainDevices')}</Paragraph>
+              <SectionBlock>
+                <TableGrid isDeviceTable={true}>
+                  <Table header={this.deviceHeader} rows={this.deviceRows} />
+                  <TableButtonGrid>
+                    <br />
+                    <Button
+                      level='secondary'
+                      type='accent'
+                      size='medium'
+                      text={getLocale('viewSyncCode')}
+                      onClick={this.onClickViewSyncCodeButton}
+                    />
+                    <Button
+                      level='primary'
+                      type='accent'
+                      size='medium'
+                      text={getLocale('addDevice')}
+                      onClick={this.onClickAddDeviceButton}
+                    />
+                  </TableButtonGrid>
+                </TableGrid>
+              </SectionBlock>
+              <Title level={2}>{getLocale('syncSettings')}</Title>
+              <Paragraph>{getLocale('syncSettingsDescription')}</Paragraph>
+              <SectionBlock>
+                <Table header={this.settingsHeader} rows={this.settingsRows} />
+              </SectionBlock>
+              <SectionBlock>
+                <Button
+                  level='primary'
+                  type='accent'
+                  size='medium'
+                  text={getLocale('leaveSyncChain')}
+                  onClick={this.onClickResetSyncButton}
+                />
+              </SectionBlock>
+            </SyncCardContent>
           </SyncCard>
         </Main>
       </EnabledContent>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "allowSyntheticDefaultImports": false,
+    "skipLibCheck": true
   },
 
   "include": [


### PR DESCRIPTION
## Changes
These css overrides would prevent Card from ever changing structure, or in fact any aspect of its design.

Impetus is to create a built-in alert style, but even if we don't go down that direction, it is necessary.

## Test plan
Everything should look exactly the same

##### Link / storybook path to visual changes
- https://brave-ui-3bt6h5km9.now.sh
<!-- can be localhost storybook or `now` deployment -->

## Integration
- [x] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [x] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [x] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [ ] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
