### PR TITLE
Grammatical Correction

### DIFF
--- a/stories/features/sync/page/fakeLocale.ts
+++ b/stories/features/sync/page/fakeLocale.ts
@@ -23,7 +23,7 @@ const locale: any = {
   syncSettings: 'Brave Sync Settings',
   settings: 'Settings',
   syncSettingsDescription:
-    'Manage the content you would like to sync between devices. These settings only effect this device.',
+    'Manage the content you would like to sync between devices. These settings only affect this device.',
   bookmarks: 'Bookmarks',
   savedSiteSettings: 'Saved Site Settings',
   browsingHistory: 'Browsing History',


### PR DESCRIPTION
Updating the usage of the verb

## Changes
- `e` swapped in for `a`

## Test plan
- Only if string matching breaks downstream screen validation. Could not find any other references, as such should have no impact on test validity

##### Link / storybook path to visual changes
- See [affect vs effect](https://en.oxforddictionaries.com/usage/affect-or-effect) in the Oxford Dictionary