### PR TITLE
Toggle widgets NTP

### DIFF
--- a/src/features/newTab/default/clock/index.tsx
+++ b/src/features/newTab/default/clock/index.tsx
@@ -4,6 +4,8 @@
 
 import * as React from 'react'
 
+import createWidget from '../widget/index'
+
 import { StyledClock, StyledTime } from './style'
 
 interface TimeComponent {
@@ -16,7 +18,7 @@ export interface ClockState {
   date: Date
 }
 
-export class Clock extends React.PureComponent<{}, ClockState> {
+class Clock extends React.PureComponent<{}, ClockState> {
   constructor (props: {}) {
     super(props)
     this.state = this.getClockState(new Date())
@@ -66,3 +68,5 @@ export class Clock extends React.PureComponent<{}, ClockState> {
     )
   }
 }
+
+export const ClockWidget = createWidget(Clock)

--- a/src/features/newTab/default/grid/index.ts
+++ b/src/features/newTab/default/grid/index.ts
@@ -10,7 +10,7 @@ export const Header = styled<{}, 'header'>('header')`
   height: 100%;
   margin: 70px 0 0;
   grid-template-columns: 1fr auto auto;
-  grid-template-rows: 1fr;
+  grid-template-rows: 100px;
   grid-gap: 30px 0;
   grid-template-areas:
     "stats clock"
@@ -31,6 +31,7 @@ export const Header = styled<{}, 'header'>('header')`
   }
 
   @media screen and (max-width: 1150px) {
+    grid-template-rows: 1fr;
     grid-template-areas:
     "clock"
     "stats"

--- a/src/features/newTab/default/index.ts
+++ b/src/features/newTab/default/index.ts
@@ -7,9 +7,10 @@ import { StatsContainer, StatsItem } from './stats'
 import { Page, DynamicBackground, Gradient, Link, Navigation, IconLink, PhotoName } from './page'
 import { Header, Main, Footer } from './grid'
 import { SettingsMenu, SettingsRow, SettingsText, SettingsTitle, SettingsWrapper } from './settings'
-import { List, Tile, TileActionsContainer, TileAction, TileFavicon } from './topSites'
+import { List, ListWidget, Tile, TileActionsContainer, TileAction, TileFavicon } from './topSites'
 import { SiteRemovalNotification, SiteRemovalText, SiteRemovalAction } from './notification'
 import { ClockWidget } from './clock'
+import createWidget from './widget'
 
 export {
   StatsContainer,
@@ -25,6 +26,7 @@ export {
   Main,
   Footer,
   List,
+  ListWidget,
   Tile,
   TileActionsContainer,
   TileAction,
@@ -37,5 +39,6 @@ export {
   SettingsRow,
   SettingsText,
   SettingsTitle,
-  SettingsWrapper
+  SettingsWrapper,
+  createWidget
 }

--- a/src/features/newTab/default/index.ts
+++ b/src/features/newTab/default/index.ts
@@ -9,7 +9,7 @@ import { Header, Main, Footer } from './grid'
 import { SettingsMenu, SettingsRow, SettingsText, SettingsTitle, SettingsWrapper } from './settings'
 import { List, Tile, TileActionsContainer, TileAction, TileFavicon } from './topSites'
 import { SiteRemovalNotification, SiteRemovalText, SiteRemovalAction } from './notification'
-import { Clock } from './clock'
+import { ClockWidget } from './clock'
 
 export {
   StatsContainer,
@@ -32,7 +32,7 @@ export {
   SiteRemovalNotification,
   SiteRemovalText,
   SiteRemovalAction,
-  Clock,
+  ClockWidget,
   SettingsMenu,
   SettingsRow,
   SettingsText,

--- a/src/features/newTab/default/settings/index.ts
+++ b/src/features/newTab/default/settings/index.ts
@@ -8,7 +8,7 @@ export const SettingsMenu = styled<{}, 'div'>('div')`
   background-color: ${p => p.theme.color.contextMenuBackground};
   color:  ${p => p.theme.color.contextMenuForeground};
   border-radius: 8px;
-  padding: 24px;
+  padding: 24px 24px 17px 24px;
   box-shadow: 0px 4px 24px 0px rgba(0, 0, 0, 0.24);
   font-family: ${p => p.theme.fontFamily.body};
 `
@@ -18,13 +18,14 @@ export const SettingsTitle = styled<{}, 'div'>('div')`
   font-size: 18px;
   font-weight: bold;
   letter-spacing: 0px;
-  margin-bottom: 16px;
+  margin-bottom: 17px;
 `
 
 export const SettingsRow = styled<{}, 'div'>('div')`
   box-sizing: border-box;
   display: grid;
   grid-template-columns: 1fr 36px;
+  margin-top: 10px;
   height: 30px;
   width: 320px;
 `

--- a/src/features/newTab/default/topSites/index.ts
+++ b/src/features/newTab/default/topSites/index.ts
@@ -3,6 +3,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import styled from '../../../../theme'
+import createWidget from '../widget'
 
 export const List = styled<{}, 'div'>('div')`
   margin: 0 70px;
@@ -100,3 +101,5 @@ export const TileFavicon = styled<{}, 'img'>('img')`
   height: 72px;
   padding: 16px;
 `
+
+export const ListWidget = createWidget(List)

--- a/src/features/newTab/default/topSites/index.ts
+++ b/src/features/newTab/default/topSites/index.ts
@@ -5,7 +5,7 @@
 import styled from '../../../../theme'
 
 export const List = styled<{}, 'div'>('div')`
-  padding: 0 70px;
+  margin: 0 70px;
   height: 100%;
   display: grid;
   grid-template-columns: repeat(6, 92px);

--- a/src/features/newTab/default/topSites/index.ts
+++ b/src/features/newTab/default/topSites/index.ts
@@ -6,7 +6,7 @@ import styled from '../../../../theme'
 import createWidget from '../widget'
 
 export const List = styled<{}, 'div'>('div')`
-  margin: 0 70px;
+  padding: 0 70px;
   height: 100%;
   display: grid;
   grid-template-columns: repeat(6, 92px);

--- a/src/features/newTab/default/widget/index.tsx
+++ b/src/features/newTab/default/widget/index.tsx
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as React from 'react'
+import { StyledWidgetContainer } from './styles'
+
+export interface WidgetProps {
+  showWidget: boolean
+}
+
+const createWidget = <P extends object>(WrappedComponent: React.ComponentType<P>) =>
+  class Widget extends React.Component<P & WidgetProps> {
+    render () {
+      const { showWidget } = this.props
+      return (
+        <StyledWidgetContainer
+          showWidget={showWidget}
+        >
+          <WrappedComponent {...this.props as P}/>
+        </StyledWidgetContainer>
+      )
+    }
+  }
+
+export default createWidget

--- a/src/features/newTab/default/widget/styles.ts
+++ b/src/features/newTab/default/widget/styles.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import styled from 'styled-components'
+import { WidgetProps } from './index'
+
+export const StyledWidgetContainer = styled<WidgetProps, 'div'>('div')`
+  display: ${p => p.showWidget ? 'initial' : 'none'};
+`

--- a/stories/features/newTab/default/index.tsx
+++ b/stories/features/newTab/default/index.tsx
@@ -5,8 +5,7 @@
 import * as React from 'react'
 
 // Feature-specific components
-import { Clock } from '../../../../src/features/newTab/default/clock'
-import { Page, Header, Main, Footer, DynamicBackground, Gradient } from '../../../../src/features/newTab/default'
+import { Page, Header, Main, Footer, DynamicBackground, Gradient, ClockWidget as Clock } from '../../../../src/features/newTab/default'
 
 import Settings from './settings'
 import TopSitesList from './topSites/topSitesList'
@@ -25,19 +24,37 @@ const generateRandomBackgroundData = getRandomBackgroundData(images)
 interface State {
   showSettings: boolean
   showBackgroundImage: boolean
+  showStats: boolean
+  showClock: boolean
+  showTopSites: boolean
 }
 
 export default class NewTabPage extends React.PureComponent<{}, State> {
   constructor (props: {}) {
     super(props)
     this.state = {
+      showSettings: false,
       showBackgroundImage: true,
-      showSettings: false
+      showStats: true,
+      showClock: true,
+      showTopSites: true
     }
   }
 
   toggleShowBackgroundImage = () => {
     this.setState({ showBackgroundImage: !this.state.showBackgroundImage })
+  }
+
+  toggleShowClock = () => {
+    this.setState({ showClock: !this.state.showClock })
+  }
+
+  toggleShowStats = () => {
+    this.setState({ showStats: !this.state.showStats })
+  }
+
+  toggleShowTopSites = () => {
+    this.setState({ showTopSites: !this.state.showTopSites })
   }
 
   showSettings = () => {
@@ -49,16 +66,22 @@ export default class NewTabPage extends React.PureComponent<{}, State> {
   }
 
   render () {
-    const { showSettings, showBackgroundImage } = this.state
+    const { showSettings, showBackgroundImage, showClock, showStats, showTopSites } = this.state
     return (
       <DynamicBackground showBackgroundImage={showBackgroundImage} background={generateRandomBackgroundData.source}>
         {showBackgroundImage && <Gradient />}
         <Page>
           <Header>
-            <Stats />
-            <Clock />
+            <Stats
+              showWidget={showStats}
+            />
+            <Clock
+              showWidget={showClock}
+            />
             <Main>
-              <TopSitesList />
+              <TopSitesList
+                showWidget={showTopSites}
+              />
               <SiteRemovalNotification />
             </Main>
           </Header>
@@ -68,6 +91,12 @@ export default class NewTabPage extends React.PureComponent<{}, State> {
               onClickOutside={this.closeSettings}
               toggleShowBackgroundImage={this.toggleShowBackgroundImage}
               showBackgroundImage={showBackgroundImage}
+              toggleShowClock={this.toggleShowClock}
+              toggleShowStats={this.toggleShowStats}
+              toggleShowTopSites={this.toggleShowTopSites}
+              showClock={showClock}
+              showStats={showStats}
+              showTopSites={showTopSites}
             />
           }
           <Footer>

--- a/stories/features/newTab/default/settings.tsx
+++ b/stories/features/newTab/default/settings.tsx
@@ -13,7 +13,13 @@ import { getLocale } from '../fakeLocale'
 interface Props {
   onClickOutside: () => void
   toggleShowBackgroundImage: () => void
+  toggleShowClock: () => void
+  toggleShowStats: () => void
+  toggleShowTopSites: () => void
   showBackgroundImage: boolean
+  showStats: boolean
+  showClock: boolean
+  showTopSites: boolean
 }
 
 export default class Settings extends React.PureComponent<Props, {}> {
@@ -38,7 +44,16 @@ export default class Settings extends React.PureComponent<Props, {}> {
   }
 
   render () {
-    const { toggleShowBackgroundImage, showBackgroundImage } = this.props
+    const {
+      toggleShowBackgroundImage,
+      toggleShowClock,
+      toggleShowStats,
+      toggleShowTopSites,
+      showBackgroundImage,
+      showStats,
+      showClock,
+      showTopSites
+    } = this.props
     return (
       <SettingsWrapper>
         <SettingsMenu innerRef={this.settingsMenuRef}>
@@ -48,6 +63,30 @@ export default class Settings extends React.PureComponent<Props, {}> {
             <Toggle
               onChange={toggleShowBackgroundImage}
               checked={showBackgroundImage}
+              size='small'
+            />
+          </SettingsRow>
+          <SettingsRow>
+            <SettingsText>{getLocale('showBraveStats')}</SettingsText>
+            <Toggle
+              onChange={toggleShowStats}
+              checked={showStats}
+              size='small'
+            />
+          </SettingsRow>
+          <SettingsRow>
+            <SettingsText>{getLocale('showClock')}</SettingsText>
+            <Toggle
+              onChange={toggleShowClock}
+              checked={showClock}
+              size='small'
+            />
+          </SettingsRow>
+          <SettingsRow>
+            <SettingsText>{getLocale('showTopSites')}</SettingsText>
+            <Toggle
+              onChange={toggleShowTopSites}
+              checked={showTopSites}
               size='small'
             />
           </SettingsRow>

--- a/stories/features/newTab/default/stats.tsx
+++ b/stories/features/newTab/default/stats.tsx
@@ -8,8 +8,9 @@ import { StatsContainer, StatsItem } from '../../../../src/features/newTab/defau
 
 // Helpers
 import { getLocale } from '../fakeLocale'
+import createWidget from '../../../../src/features/newTab/default/widget'
 
-export default class Stats extends React.PureComponent<{}, {}> {
+class Stats extends React.PureComponent<{}, {}> {
   render () {
     return (
       <StatsContainer>
@@ -21,3 +22,5 @@ export default class Stats extends React.PureComponent<{}, {}> {
     )
   }
 }
+
+export default createWidget(Stats)

--- a/stories/features/newTab/default/topSites/topSitesList.tsx
+++ b/stories/features/newTab/default/topSites/topSitesList.tsx
@@ -10,6 +10,7 @@ import { reorder, getItems } from '../helpers'
 
 // Feature-specific components
 import { List } from '../../../../../src/features/newTab/default'
+import createWidget from '../../../../../src/features/newTab/default/widget'
 
 // Component group
 import TopSite from './topSite'
@@ -20,7 +21,7 @@ interface State {
   items: Array<any>
 }
 
-export default class TopSitesList extends React.PureComponent<Props, State> {
+class TopSitesList extends React.PureComponent<Props, State> {
   constructor (props: Props) {
     super(props)
     this.state = { items: getItems() }
@@ -53,3 +54,5 @@ export default class TopSitesList extends React.PureComponent<Props, State> {
     )
   }
 }
+
+export default createWidget(TopSitesList)

--- a/stories/features/newTab/fakeLocale.ts
+++ b/stories/features/newTab/fakeLocale.ts
@@ -18,7 +18,10 @@ const locale: any = {
   close: 'Close',
   // settings
   dashboardSettings: 'Dashboard Settings',
-  showBackgroundImg: 'Show background image'
+  showBackgroundImg: 'Show background image',
+  showBraveStats: 'Show Brave Stats',
+  showClock: 'Show Clock',
+  showTopSites: 'Show Top Sites'
 }
 
 export default locale


### PR DESCRIPTION
Spec: https://github.com/brave/brave-browser/issues/4510
## Changes
- Added more options in the settings menu to toggle the showing of widgets
- Each of the three widgets (Stats, Clock, TopSites) will show/hide from the menu
- Quick View:
![toggle-widgets](https://user-images.githubusercontent.com/9125231/59808938-453df380-92b3-11e9-99bb-025bc9b5578d.gif)

## Test plan
- Ensure menu opens and closes properly
- Ensure widgets display properly independently of whether the other widgets are being shown
- Ensure widgets can toggle from the menu

##### Link / storybook path to visual changes
- https://brave-ui.imptrx.now.sh/?path=/story/feature-components-new-tab-default--page

<!-- can be localhost storybook or `now` deployment -->

## Integration
- [ ] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [x] Does this contain changes to src/features for brave-core?
  - [x] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
https://github.com/brave/brave-core/pull/2762
  - [x] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
