### PR TITLE
Enable setting menu to be accessible via NTP

### DIFF
--- a/src/features/newTab/default/index.ts
+++ b/src/features/newTab/default/index.ts
@@ -4,7 +4,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { StatsContainer, StatsItem } from './stats'
-import { Page, DynamicBackground, Gradient, Link, Navigation, IconLink, PhotoName } from './page'
+import { Page, DynamicBackground, Gradient, Link, Navigation, IconLink, IconButton, PhotoName } from './page'
 import { Header, Main, Footer } from './grid'
 import { SettingsMenu, SettingsRow, SettingsText, SettingsTitle, SettingsWrapper } from './settings'
 import { List, Tile, TileActionsContainer, TileAction, TileFavicon } from './topSites'
@@ -20,6 +20,7 @@ export {
   Link,
   Navigation,
   IconLink,
+  IconButton,
   PhotoName,
   Header,
   Main,

--- a/src/features/newTab/default/page/index.ts
+++ b/src/features/newTab/default/page/index.ts
@@ -90,18 +90,36 @@ export const Navigation = styled<{}, 'nav'>('nav')`
   display: flex;
 `
 
-interface IconLinkProps {
-  disabled?: boolean
+interface IconButtonProps {
+  clickDisabled?: boolean
 }
 
-export const IconLink = styled<IconLinkProps, 'a'>('a')`
-  pointer-events: ${p => p.disabled && 'none'};
+export const IconLink = styled<{}, 'a'>('a')`
   display: flex;
   width: 24px;
   height: 24px;
   margin: 12px;
   cursor: pointer;
   color: #ffffff;
+  opacity: 0.7;
+  transition: opacity 0.15s ease, filter 0.15s ease;
+
+  &:hover {
+    opacity: 0.95;
+  }
+`
+
+export const IconButton = styled<IconButtonProps, 'button'>('button')`
+  pointer-events: ${p => p.clickDisabled && 'none'};
+  display: flex;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  margin: 12px;
+  cursor: pointer;
+  color: #ffffff;
+  background-color: transparent;
   opacity: 0.7;
   transition: opacity 0.15s ease, filter 0.15s ease;
 

--- a/stories/features/newTab/default/footerInfo.tsx
+++ b/stories/features/newTab/default/footerInfo.tsx
@@ -5,7 +5,7 @@
 import * as React from 'react'
 
 // Feature-specific components
-import { Link, Navigation, IconLink, PhotoName } from '../../../../src/features/newTab/default'
+import { Link, Navigation, IconLink, IconButton, PhotoName } from '../../../../src/features/newTab/default'
 
 // Icons
 import { SettingsAdvancedIcon, BookmarkBook, HistoryIcon, SettingsIcon } from '../../../../src/components/icons'
@@ -21,6 +21,13 @@ interface Props {
 }
 
 export default class FooterInfo extends React.PureComponent<Props, {}> {
+
+  onKeyPressSettings = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === ' ' || e.key === 'Enter') {
+      this.props.onClickSettings()
+    }
+  }
+
   render () {
     const {
       backgroundImageInfo,
@@ -41,7 +48,13 @@ export default class FooterInfo extends React.PureComponent<Props, {}> {
           </PhotoName>}
         </div>
         <Navigation>
-          <IconLink onClick={onClickSettings} disabled={isSettingsMenuOpen}><SettingsIcon /></IconLink>
+          <IconButton
+            onMouseDown={onClickSettings}
+            disabled={isSettingsMenuOpen}
+            onKeyDown={this.onKeyPressSettings}
+          >
+            <SettingsIcon />
+          </IconButton>
           <IconLink><SettingsAdvancedIcon /></IconLink>
           <IconLink><BookmarkBook /></IconLink>
           <IconLink><HistoryIcon /></IconLink>

--- a/stories/features/newTab/default/index.tsx
+++ b/stories/features/newTab/default/index.tsx
@@ -40,12 +40,8 @@ export default class NewTabPage extends React.PureComponent<{}, State> {
     this.setState({ showBackgroundImage: !this.state.showBackgroundImage })
   }
 
-  showSettings = () => {
-    this.setState({ showSettings: true })
-  }
-
-  closeSettings = () => {
-    this.setState({ showSettings: false })
+  toggleSettings = () => {
+    this.setState({ showSettings: !this.state.showSettings })
   }
 
   render () {
@@ -65,7 +61,7 @@ export default class NewTabPage extends React.PureComponent<{}, State> {
           {
             showSettings &&
             <Settings
-              onClickOutside={this.closeSettings}
+              onClickOutside={this.toggleSettings}
               toggleShowBackgroundImage={this.toggleShowBackgroundImage}
               showBackgroundImage={showBackgroundImage}
             />
@@ -73,7 +69,7 @@ export default class NewTabPage extends React.PureComponent<{}, State> {
           <Footer>
             <FooterInfo
               backgroundImageInfo={generateRandomBackgroundData}
-              onClickSettings={this.showSettings}
+              onClickSettings={this.toggleSettings}
               isSettingsMenuOpen={showSettings}
               showPhotoInfo={showBackgroundImage}
             />


### PR DESCRIPTION
Spec: https://github.com/brave/brave-browser/issues/5041

## Changes
- You can now open the settings menu via keyboard


Quick View:
![keyboard-settings](https://user-images.githubusercontent.com/9125231/60217527-c3554980-9821-11e9-8abc-b2c97d6f5a45.gif)
## Test plan
- Go to new tabs page 
- Press tab 
- There should be an outline when you reach the settings icon at the bottom left of the page
- Pressing `space` or `enter` will open the setting menu
- Pressing tab will allow you to select the setting menu icon again
- Pressing `space` or `enter` will open the setting menu

##### Link / storybook path to visual changes
- https://brave-ui-fgdae6j9x.now.sh/?path=/story/feature-components-new-tab-default--page
<!-- can be localhost storybook or `now` deployment -->

## Integration
- [ ] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [ ] Does this contain changes to src/features for brave-core?
  - [x] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR: 
- https://github.com/brave/brave-core/pull/2814
  - [x] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
