### PR TITLE
Adjust media query boundaries to account for large stats and margins

### DIFF
--- a/src/features/newTab/default/grid/index.ts
+++ b/src/features/newTab/default/grid/index.ts
@@ -30,7 +30,7 @@ export const Header = styled<{}, 'header'>('header')`
     grid-area: topsites;
   }
 
-  @media screen and (max-width: 904px) {
+  @media screen and (max-width: 1150px) {
     grid-template-areas:
     "clock"
     "stats"
@@ -75,7 +75,7 @@ export const Footer = styled<{}, 'footer'>('footer')`
       grid-area: actions;
     }
 
-  @media screen and (max-width: 904px) {
+  @media screen and (max-width: 1150px) {
     margin: 70px 40px;
 
     grid-template-areas:

--- a/src/features/newTab/default/settings/index.ts
+++ b/src/features/newTab/default/settings/index.ts
@@ -44,7 +44,7 @@ export const SettingsWrapper = styled<{}, 'div'>('div')`
   width: 100%;
   justify-content: flex-end;
 
-  @media screen and (max-width: 904px) {
+  @media screen and (max-width: 1150px) {
     padding: 0 192px;
   }
 `

--- a/src/features/newTab/default/topSites/index.ts
+++ b/src/features/newTab/default/topSites/index.ts
@@ -10,7 +10,7 @@ export const List = styled<{}, 'div'>('div')`
   display: grid;
   grid-template-columns: repeat(6, 92px);
 
-  @media screen and (max-width: 904px) {
+  @media screen and (max-width: 1150px) {
     justify-content: center;
     padding: 40px;
   }


### PR DESCRIPTION
Issue: https://github.com/brave/brave-browser/issues/5038
Technicals Description:
- Currently users with very high stats numbers make the stats element bigger. In conjunction with margins on the widget themselves, overflow is created on NTP.
- Vertical scroll bars appear because horizontal scroll bars take up page space

Quick view:

## Changes
- Adjust media query margins to be larger to account for margins and scroll bars

## Test plan
- Open New tabs page
- Slowly shrink window and see if horizontal/vertical scroll bars appear
- Note: Beyond a certain size, shrinking will always produce vertical scroll bars since the page physically doesn't fit the elements

##### Link / storybook path to visual changes
- https://brave-ui-mbnub1i2y.now.sh/?path=/story/feature-components-new-tab-default--page
<!-- can be localhost storybook or `now` deployment -->

## Integration
- [ ] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [x] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
https://github.com/brave/brave-core/pull/2826
  - [ ] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
