### PR TITLE
✨ Inline theme selection at on-boarding

### DIFF
--- a/stories/features/welcome/page/fakeLocale.ts
+++ b/stories/features/welcome/page/fakeLocale.ts
@@ -25,7 +25,12 @@ const locale = {
   fakeSearchProvider2: 'Google (default)',
   // fourth screen
   chooseYourTheme: 'Choose your color theme',
+  selectTheme: 'Select a theme',
   findToolbarTheme: 'Set the color of your toolbar by selecting the light or dark option from the settings panel.',
+  themeOption1: 'Light',
+  themeOption2: 'Dark',
+  themeOption3: 'System theme (default)',
+
   // fifth screen
   protectYourPrivacy: 'Manage your shields',
   adjustProtectionLevel: 'Protect against privacy-invading ads and trackers while browsing with Brave Shields. Set Shields to "down" if a site doesn’t seem to be working properly.',

--- a/stories/features/welcome/page/screens/themeBox.tsx
+++ b/stories/features/welcome/page/screens/themeBox.tsx
@@ -5,7 +5,8 @@
 import * as React from 'react'
 
 // Feature-specific components
-import { Content, Title, Paragraph, PrimaryButton } from '../../../../../src/features/welcome/'
+import { Content, Title, Paragraph, PrimaryButton, SelectGrid } from '../../../../../src/features/welcome/'
+import { SelectBox } from '../../../../../src/features/welcome'
 
 // Utils
 import locale from '../fakeLocale'
@@ -19,9 +20,30 @@ interface Props {
   onClick: () => void
 }
 
-export default class ThemingBox extends React.PureComponent<Props, {}> {
+interface State {
+  themeSelected: boolean
+}
+
+export default class ThemingBox extends React.PureComponent<Props, State> {
+
+  constructor (props: Props) {
+    super(props)
+    this.state = {
+      themeSelected: false
+    }
+  }
+
+  onClickSelectTheme = () => {
+    this.props.onClick()
+  }
+
+  onChangeThemeOption = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    this.setState({ themeSelected: event.target.value !== '' })
+  }
+
   render () {
-    const { index, currentScreen, onClick } = this.props
+    const { index, currentScreen } = this.props
+    const { themeSelected } = this.state
     return (
       <Content
         zIndex={index}
@@ -32,13 +54,22 @@ export default class ThemingBox extends React.PureComponent<Props, {}> {
         <WelcomeThemeImage />
         <Title>{locale.chooseYourTheme}</Title>
         <Paragraph>{locale.findToolbarTheme}</Paragraph>
-          <PrimaryButton
-            level='primary'
-            type='accent'
-            size='large'
-            text={locale.theme}
-            onClick={onClick}
-          />
+        <SelectGrid>
+            <SelectBox onChange={this.onChangeThemeOption}>
+              <option value=''>{locale.selectTheme}</option>
+              <option value='Light'>{locale.themeOption1}</option>
+              <option value='Dark'>{locale.themeOption2}</option>
+              <option value='System'>{locale.themeOption3}</option>
+            </SelectBox>
+            <PrimaryButton
+              level='primary'
+              type='accent'
+              size='large'
+              text={locale.confirm}
+              disabled={!themeSelected}
+              onClick={this.onClickSelectTheme}
+            />
+        </SelectGrid>
       </Content>
     )
   }


### PR DESCRIPTION
Spec: https://github.com/brave/brave-browser/issues/4992
Quick View:
![welcome-theme](https://user-images.githubusercontent.com/9125231/60921623-c7389100-a24f-11e9-83ad-d6686fe4aa49.gif)

## Changes
- inline option to select theme during onboarding

## Test plan
- go to brave://welcome
- at the 4th screen during the on-boarding process you now have a dropdown to select theme
- button is disabled unless a valid option is selected
- clicking the confirm should go to next screen

##### Link / storybook path to visual changes
- https://brave-ui-iwtuqykho.now.sh/?path=/story/feature-components-welcome--page
<!-- can be localhost storybook or `now` deployment -->

## Integration
- [ ] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [ ] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [ ] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
