### PR TITLE
Add webcompat reporter modal dialog

### DIFF
--- a/src/features/webcompatreporter/display.ts
+++ b/src/features/webcompatreporter/display.ts
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import styled from '../../theme'
+import { TextSection } from './structure'
+import { CheckCircleIcon } from '../../../src/components/icons'
+
+export const ModalTitle = styled(TextSection)`
+  box-sizing: border-box;
+  font-size: 20px;
+  font-family: ${p => p.theme.fontFamily.heading};
+  line-height: 20px;
+  font-weight: 500;
+  color: ${p => p.theme.color.text};
+  margin: 0;
+`
+
+export const InfoText = styled(TextSection)`
+  box-sizing: border-box;
+  color: ${p => p.theme.color.text};
+  font-size: 14px;
+  font-family: ${p => p.theme.fontFamily.body};
+  margin: 0;
+  line-height: 1.2;
+`
+
+export const DisclaimerText = styled(TextSection)`
+  box-sizing: border-box;
+  color: ${p => p.theme.color.text};
+  font-size: 12px;
+  font-family: ${p => p.theme.fontFamily.body};
+  margin: 0;
+  line-height: 1.2;
+`
+
+export const NonInteractiveURL = styled<{}, 'p'>('p')`
+  box-sizing: border-box;
+  -webkit-appearance: none;
+  color: ${p => p.theme.color.brandBrave};
+  border: 0;
+  padding: 0;
+  background: transparent;
+  font-size: 14px;
+  font-weight: 500;
+  display: inline-block;
+  text-align: left;
+  width: fit-content;
+`
+
+export const SuccessIcon = styled(CheckCircleIcon)`
+  color: ${p => p.theme.color.subtle};
+  width: 30px;
+  margin-right: 10px;
+`

--- a/src/features/webcompatreporter/index.ts
+++ b/src/features/webcompatreporter/index.ts
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export {
+  SideBySideButtons,
+  ModalLayout,
+  PaddedButton,
+  TextSection,
+  IconTitle
+} from './structure'
+
+export {
+  ModalTitle,
+  InfoText,
+  DisclaimerText,
+  NonInteractiveURL,
+  SuccessIcon
+} from './display'

--- a/src/features/webcompatreporter/structure.ts
+++ b/src/features/webcompatreporter/structure.ts
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import styled from '../../theme'
+import Button, { Props as ButtonProps } from '../../components/buttonsIndicators/button'
+import { ComponentType } from 'react'
+
+export const SideBySideButtons = styled<{}, 'div'>('div')`
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  margin-top: 10px;
+`
+
+export const ModalLayout = styled<{}, 'div'>('div')`
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: space-around;
+  min-height: 100px;
+`
+
+export const PaddedButton = styled(Button as ComponentType<ButtonProps>)`
+  margin: 5px;
+`
+
+export const TextSection = styled<{}, 'div'>('div')`
+  margin: 6px 0 !important;
+`
+
+export const IconTitle = styled<{}, 'div'>('div')`
+  display: flex;
+  flex-direction: row;
+`

--- a/stories/features/webcompatreporter/components/ConfirmationView.tsx
+++ b/stories/features/webcompatreporter/components/ConfirmationView.tsx
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as React from 'react'
+
+// Components group
+import {
+  ModalLayout,
+  SuccessIcon,
+  IconTitle,
+  ModalTitle,
+  TextSection,
+  InfoText
+} from '../../../../src/features/webcompatreporter'
+
+// Fake data
+import { getLocale } from '../fakeLocale'
+
+export default class WebcompatReportModal extends React.PureComponent<{}, {}> {
+  constructor (props: {}) {
+    super(props)
+  }
+
+  render () {
+    return (
+      <ModalLayout>
+        <IconTitle>
+          <SuccessIcon />
+          <ModalTitle>{getLocale('thankYou')}</ModalTitle>
+        </IconTitle>
+        <TextSection>
+          <InfoText>{getLocale('confirmationNotice')}</InfoText>
+        </TextSection>
+      </ModalLayout>
+    )
+  }
+}

--- a/stories/features/webcompatreporter/components/ReportView.tsx
+++ b/stories/features/webcompatreporter/components/ReportView.tsx
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as React from 'react'
+
+// Components group
+import {
+  ModalLayout,
+  ModalTitle,
+  TextSection,
+  InfoText,
+  NonInteractiveURL,
+  DisclaimerText,
+  SideBySideButtons,
+  PaddedButton
+} from '../../../../src/features/webcompatreporter'
+
+// Fake data
+import { getLocale } from '../fakeLocale'
+
+interface Props {
+  siteUrl: string
+  onSubmitReport: () => void
+  onClose: () => void
+}
+
+export default class WebcompatReportModal extends React.PureComponent<Props, {}> {
+  constructor (props: Props) {
+    super(props)
+  }
+
+  render () {
+    const {
+      siteUrl,
+      onSubmitReport,
+      onClose
+    } = this.props
+    return (
+      <ModalLayout>
+        <TextSection>
+          <ModalTitle>{getLocale('reportModalTitle')}</ModalTitle>
+        </TextSection>
+        <InfoText>{getLocale('reportExplanation')}</InfoText>
+        <NonInteractiveURL>{siteUrl}</NonInteractiveURL>
+        <DisclaimerText>{getLocale('reportDisclaimer')}</DisclaimerText>
+        <SideBySideButtons>
+          <PaddedButton
+            text={getLocale('cancel')}
+            level={'secondary'}
+            type={'default'}
+            size={'small'}
+            onClick={onClose}
+          />
+          <PaddedButton
+            text={getLocale('submit')}
+            level={'primary'}
+            type={'accent'}
+            size={'small'}
+            onClick={onSubmitReport}
+          />
+        </SideBySideButtons>
+      </ModalLayout>
+    )
+  }
+}

--- a/stories/features/webcompatreporter/fakeLocale.ts
+++ b/stories/features/webcompatreporter/fakeLocale.ts
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License. v. 2.0. If a copy of the MPL was not distributed with this file.
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const locale: { [key: string]: string } = {
+  // Report modal
+  reportModalTitle: 'Report a broken site',
+  reportExplanation: 'Let Brave\'s developers know that this site doesn\'t work properly with Shields:',
+  reportDisclaimer: 'Note: This site address will be submitted with your Brave version number and your IP address (which will not be stored).',
+  cancel: 'Cancel',
+  submit: 'Submit',
+  // Confirmation modal
+  thankYou: 'Thank you!',
+  confirmationNotice: 'Thanks for letting Brave\'s developers know that there\'s something wrong with this site. We\'ll do our best to fix it!'
+}
+
+export default locale
+
+export const getLocale = (word: string) => locale[word]

--- a/stories/features/webcompatreporter/index.tsx
+++ b/stories/features/webcompatreporter/index.tsx
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as React from 'react'
+
+// Components group
+import ReportView from './components/ReportView'
+import ConfirmationView from './components/ConfirmationView'
+import { Card } from '../../../src/components'
+
+interface Props {
+  siteUrl: string
+  submitted: boolean
+  onSubmitReport: () => void
+  onClose: () => void
+}
+
+export default class WebcompatReportModal extends React.PureComponent<Props, {}> {
+  constructor (props: Props) {
+    super(props)
+  }
+
+  render () {
+    const {
+      siteUrl,
+      submitted,
+      onSubmitReport,
+      onClose
+    } = this.props
+    return (
+      <Card>
+        {submitted ? (
+          <ConfirmationView/>
+        ) : (
+          <ReportView
+            siteUrl={siteUrl}
+            onSubmitReport={onSubmitReport}
+            onClose={onClose}
+          />
+        )}
+      </Card>
+    )
+  }
+}

--- a/stories/features/webcompatreporter/story.tsx
+++ b/stories/features/webcompatreporter/story.tsx
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as React from 'react'
+import { storiesOf } from '@storybook/react'
+import defaultTheme from '../../../src/theme/brave-default'
+import { withThemesProvider } from 'storybook-addon-styled-component-theme'
+// @ts-ignore
+import { withKnobs, boolean, number } from '@storybook/addon-knobs'
+import { withState } from '@dump247/storybook-state'
+
+// Components
+import WebcompatReportModal from './index'
+
+// Themes
+const themes = [defaultTheme]
+
+storiesOf('Feature Components/Webcompat Reporter', module)
+  .addDecorator(withThemesProvider(themes))
+  .addDecorator(withKnobs)
+  .add('Report modal', withState({ siteUrl: 'https://www.buzzfeed.com/', submitted: false }, (store) => {
+    const fakeOnSubmit = () => {
+      store.set({ submitted: true })
+    }
+    const fakeOnClose = () => { /* noop */ }
+    return (
+      <div style={{ width: '375px', margin: '0 auto' }}>
+        <WebcompatReportModal
+          siteUrl={store.state.siteUrl}
+          submitted={store.state.submitted}
+          onSubmitReport={fakeOnSubmit}
+          onClose={fakeOnClose}
+        />
+      </div>
+    )
+  }))


### PR DESCRIPTION
## Changes

Added new components to support a new modal dialog for reporting web compatibility issues, as detailed [here](https://docs.google.com/document/d/1m8o9S4yOak2EiwEOHKX1_upDkhCMCn5zMHBVBWsL-AM/edit#heading=h.rtx9029pad9p) and at https://github.com/brave/brave-browser/issues/4262.

## Test plan


##### Link / storybook path to visual changes
- http://localhost:9091/?path=/story/feature-components-webcompat-reporter--report-modal
<!-- can be localhost storybook or `now` deployment -->

## Integration
- [ ] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [ ] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [ ] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
