### PR TITLE
Use new button styles

### DIFF
--- a/src/components/buttonsIndicators/button/index.tsx
+++ b/src/components/buttonsIndicators/button/index.tsx
@@ -4,6 +4,7 @@
 
 import * as React from 'react'
 import {
+  DefaultButton,
   PrimaryButton,
   SecondaryButton,
   TertiaryButton,
@@ -14,10 +15,8 @@ import {
 export interface Props {
   text: string
   size?: Size
-  type?: Type
   brand?: Brand
   level?: Level
-  main?: boolean
   onClick?: () => void
   id?: string
   disabled?: boolean
@@ -25,8 +24,7 @@ export interface Props {
   className?: string
 }
 
-export type Level = 'primary' | 'secondary' | 'tertiary'
-export type Type = 'default' | 'accent' | 'warn' | 'subtle'
+export type Level = 'default' | 'primary' | 'secondary' | 'tertiary'
 export type Brand = 'brave' | 'rewards'
 export type Size = 'call-to-action' | 'large' | 'medium' | 'small'
 
@@ -36,13 +34,13 @@ export default class ThemedButton extends React.PureComponent<Props, {}> {
   static defaultProps = {
     brand: 'brave',
     size: 'medium',
-    type: 'default',
-    level: 'primary',
-    main: false
+    level: 'default'
   }
 
   getButtonComponent () {
     switch (this.props.level) {
+      case 'default':
+        return DefaultButton
       case 'primary':
         return PrimaryButton
       case 'secondary':

--- a/src/components/buttonsIndicators/button/style.ts
+++ b/src/components/buttonsIndicators/button/style.ts
@@ -21,51 +21,35 @@ function largeMediumSmall (largeValue: any, mediumValue: any, smallValue: any, c
 }
 
 const getThemeColors = (p: ThemedStyledProps<Props>) => {
-  let mainColor
+  let subtleBackgroundColor
   let hoverColor
-  let activeColor
-  if (p.disabled) {
-    mainColor = hoverColor = activeColor = p.theme.color.disabled
-  } else {
-    switch (p.type) {
-      case 'accent':
-        if (p.brand === 'brave') {
-          mainColor = p.theme.color.brandBrave
-          hoverColor = p.theme.color.brandBraveInteracting
-          activeColor = p.theme.color.brandBraveActive
-        } else if (p.brand === 'rewards') {
-          mainColor = p.theme.color.brandBat
-          hoverColor = p.theme.color.brandBatInteracting
-          activeColor = p.theme.color.brandBatActive
-        }
-        break
-      case 'default':
-        mainColor = p.theme.color.defaultControl
-        hoverColor = p.theme.color.defaultControlInteracting
-        activeColor = p.theme.color.defaultControlActive
-        break
-      case 'warn':
-        mainColor = p.theme.color.warn
-        hoverColor = p.theme.color.warnInteracting
-        activeColor = p.theme.color.warnActive
-        break
-      case 'subtle':
-        mainColor = p.theme.color.subtle
-        hoverColor = p.theme.color.subtleInteracting
-        activeColor = p.theme.color.subtleActive
-        break
-    }
+  let mainColor
+  let pressedColor
+  let outlineColor
+  if (p.brand === 'brave') {
+    subtleBackgroundColor = p.theme.color.brandBraveSubtleBackground
+    hoverColor = p.theme.color.brandBraveHover
+    mainColor = p.theme.color.brandBraveMain
+    pressedColor = p.theme.color.brandBravePressed
+    outlineColor = p.theme.color.brandBraveOutline
+  } else if (p.brand === 'rewards') {
+    subtleBackgroundColor = p.theme.color.brandBatSubtleBackground
+    hoverColor = p.theme.color.brandBatHover
+    mainColor = p.theme.color.brandBatMain
+    pressedColor = p.theme.color.brandBatPressed
+    outlineColor = p.theme.color.brandBatOutline
   }
   return css`
-    --button-main-color: ${mainColor};
-    --button-main-color-hover: ${hoverColor};
-    --button-main-color-active: ${activeColor};
+    --brand-color-subtle: ${subtleBackgroundColor};
+    --brand-color-hover: ${hoverColor};
+    --brand-color-main: ${mainColor};
+    --brand-color-pressed: ${pressedColor};
+    --brand-style-focus-shadow: 0 0 0 4px ${outlineColor};
   `
 }
 
 const StyledButton = styled<Props, 'button'>('button')`
   ${getThemeColors}
-  --button-state-color: var(--button-main-color);
   --icon-size: ${largeMediumSmall('18px', '16px', '14px')};
   --icon-spacing: ${largeMediumSmall('6px', '6px', '6px')};
   --webkit-appearance: none;
@@ -77,37 +61,87 @@ const StyledButton = styled<Props, 'button'>('button')`
   flex-direction: ${p => p.icon && p.icon.position === 'after' ? 'row' : 'row-reverse'};
   justify-content: center;
   align-items: center;
-  font-family: Poppins, sans-serif;
+  font-family: Muli, sans-serif;
   cursor: ${p => p.disabled ? 'default' : 'pointer'};
   user-select: none;
-  font-size: ${largeMediumSmall('14px', '13px', '11px')};
+  font-size: ${largeMediumSmall('16px', '14px', '13px')};
   border-radius: ${largeMediumSmall('24px', '20px', '16px', '28px')};
   width: ${p => p.size === 'call-to-action' ? '100%' : 'auto'};
-  min-width: ${largeMediumSmall('116px', '104px', '88px', '235px')};
-  padding: ${largeMediumSmall('14px 15px', '11px 15px', '7px 10px', '19px 15px')};
-  :hover:enabled {
-    --button-state-color: var(--button-main-color-hover);
-  }
-  :active:enabled {
-    --button-state-color: var(--button-main-color-active);
-  }
+  min-width: ${largeMediumSmall('85px', '82px', '68px', '235px')};
+  padding: ${largeMediumSmall('13px 20px', '9px 16px', '5px 16px', '19px 15px')};
+  opacity: ${p => p.disabled ? '0.4' : 'none'};
 `
 
 export default StyledButton
 
+export const DefaultButton = styled(StyledButton)`
+  color: ${p => p.theme.color.defaultControl};
+  border: 1px solid ${p => p.theme.color.defaultButtonBorder};
+  :hover:enabled {
+    color: var(--brand-color-main);
+    border-color: var(--brand-color-main);
+  }
+  :focus:enabled {
+    border-color: var(--brand-color-main);
+    box-shadow: var(--brand-style-focus-shadow);
+  }
+  :active:enabled {
+    color: var(--brand-color-main);
+    border-color: var(--brand-color-main);
+    box-shadow: var(--brand-style-focus-shadow);
+  }
+`
+
 export const PrimaryButton = styled(StyledButton)`
   color: #fff;
-  background: var(--button-state-color);
-  border: 1px solid var(--button-state-color);
+  background: var(--brand-color-main);
+  :hover:enabled {
+    background: var(--brand-color-hover);
+  }
+  :focus:enabled {
+    background: var(--brand-color-main);
+    box-shadow: var(--brand-style-focus-shadow);
+  }
+  :active:enabled {
+    background: var(--brand-color-main);
+    box-shadow: var(--brand-style-focus-shadow);
+  }
 `
 
 export const SecondaryButton = styled(StyledButton)`
-  border: 1px solid;
-  color: var(--button-state-color);
+  color: var(--brand-color-main);
+  :hover:enabled {
+    background: var(--brand-color-subtle);
+    color: var(--brand-color-main);
+  }
+  :focus:enabled {
+    background: var(--brand-color-subtle);
+    color: var(--brand-color-main);
+    box-shadow: var(--brand-style-focus-shadow);
+  }
+  :active:enabled {
+    background: var(--brand-color-subtle);
+    color: var(--brand-color-pressed);
+    box-shadow: var(--brand-style-focus-shadow);
+  }
 `
 
 export const TertiaryButton = styled(StyledButton)`
-  color: var(--button-state-color);
+  color: ${p => p.theme.color.defaultControl};
+  :hover:enabled {
+    background: var(--brand-color-subtle);
+    color: var(--brand-color-main);
+  }
+  :focus:enabled {
+    background: var(--brand-color-subtle);
+    color: var(--brand-color-main);
+    box-shadow: var(--brand-style-focus-shadow);
+  }
+  :active:enabled {
+    background: var(--brand-color-subtle);
+    color: var(--brand-color-pressed);
+    box-shadow: var(--brand-style-focus-shadow);
+  }
 `
 
 export const StyledText = styled<Props, 'div'>('div')`
@@ -117,7 +151,7 @@ export const StyledText = styled<Props, 'div'>('div')`
   align-items: center;
   text-align: center;
   letter-spacing: 0;
-  font-weight: 500;
+  font-weight: ${p => p.level === 'primary' ? 700 : 600};
   text-transform: ${p => p.size === 'call-to-action' ? 'uppercase' : 'none'};
   line-height: 1;
 `

--- a/src/components/popupModals/alertBox/index.tsx
+++ b/src/components/popupModals/alertBox/index.tsx
@@ -13,16 +13,12 @@ export interface Props {
   onClickOk?: () => void
   cancelString?: string
   okString: string
-  colorType: 'default' | 'accent' | 'warn' | 'subtle'
 }
 
 export default class AlertBox extends React.PureComponent<Props, {}> {
-  static defaultProps = {
-    colorType: 'accent'
-  }
   render () {
     const { testId, children, ...buttonProps } = this.props
-    const { colorType, onClickCancel, cancelString, onClickOk, okString } = buttonProps
+    const { onClickCancel, cancelString, onClickOk, okString } = buttonProps
     return (
       <StyledDialogWrapper>
       <StyledDialog data-test-id={testId}>
@@ -31,11 +27,11 @@ export default class AlertBox extends React.PureComponent<Props, {}> {
           <StyledCancelContainer>
             {
               cancelString
-                ? <Button type={colorType} level='secondary' onClick={onClickCancel} text={cancelString} />
+                ? <Button onClick={onClickCancel} text={cancelString} />
                 : null
             }
           </StyledCancelContainer>
-          <Button type={colorType} onClick={onClickOk} text={okString} />
+          <Button level='primary' onClick={onClickOk} text={okString} />
         </StyledFooter>
       </StyledDialog>
       </StyledDialogWrapper>

--- a/src/features/rewards/boxAlert/index.tsx
+++ b/src/features/rewards/boxAlert/index.tsx
@@ -100,7 +100,7 @@ export default class BoxAlert extends React.PureComponent<Props, State> {
               <Button
                 text={getLocale('ok')}
                 size={'call-to-action'}
-                type={'accent'}
+                level={'primary'}
                 onClick={this.toggleModalDisplay}
               />
             </StyledButton>

--- a/src/features/rewards/grantComplete/index.tsx
+++ b/src/features/rewards/grantComplete/index.tsx
@@ -53,7 +53,7 @@ export default class GrantComplete extends React.PureComponent<Props, {}> {
           <Button
             text={getLocale('ok')}
             size={'call-to-action'}
-            type={'accent'}
+            level={'primary'}
             onClick={onClose}
             id={'grant-completed-ok'}
           />

--- a/src/features/rewards/grantError/index.tsx
+++ b/src/features/rewards/grantError/index.tsx
@@ -26,7 +26,7 @@ export default class GrantError extends React.PureComponent<Props, {}> {
           <Button
             text={buttonText}
             size={'call-to-action'}
-            type={'accent'}
+            level={'primary'}
             onClick={onButtonClick}
           />
         </StyledButton>

--- a/src/features/rewards/modalAddFunds/index.tsx
+++ b/src/features/rewards/modalAddFunds/index.tsx
@@ -99,7 +99,7 @@ export default class ModalAddFunds extends React.PureComponent<Props, State> {
                   <StyledQRButton
                     size={'large'}
                     brand={'rewards'}
-                    type={'accent'}
+                    level={'primary'}
                     text={getLocale('addFundsQR')}
                     onClick={this.onQR.bind(this, address.type)}
                   />

--- a/src/features/rewards/modalBackupRestore/index.tsx
+++ b/src/features/rewards/modalBackupRestore/index.tsx
@@ -124,9 +124,8 @@ export default class ModalBackupRestore extends React.PureComponent<Props, State
             onCopy
             ? <GroupedButton
               text={getLocale('copy')}
-              level={'secondary'}
+              level={'tertiary'}
               size={'small'}
-              type={'subtle'}
               onClick={onCopy.bind(this, backupKey)}
             />
             : null
@@ -135,9 +134,8 @@ export default class ModalBackupRestore extends React.PureComponent<Props, State
             onPrint
             ? <GroupedButton
               text={getLocale('print')}
-              level={'secondary'}
+              level={'tertiary'}
               size={'small'}
-              type={'subtle'}
               onClick={onPrint.bind(this, backupKey)}
             />
             : null
@@ -146,9 +144,8 @@ export default class ModalBackupRestore extends React.PureComponent<Props, State
             onSaveFile
             ? <GroupedButton
               text={getLocale('saveAsFile')}
-              level={'secondary'}
+              level={'tertiary'}
               size={'small'}
-              type={'subtle'}
               onClick={onSaveFile.bind(this, backupKey)}
             />
             : null
@@ -163,8 +160,8 @@ export default class ModalBackupRestore extends React.PureComponent<Props, State
         <StyledDoneWrapper>
           <Button
             text={getLocale('done')}
+            level={'primary'}
             size={'medium'}
-            type={'accent'}
             onClick={onClose}
           />
         </StyledDoneWrapper>
@@ -227,15 +224,13 @@ export default class ModalBackupRestore extends React.PureComponent<Props, State
         </StyledTextWrapper>
         <StyledActionsWrapper>
           <ActionButton
-            level={'secondary'}
+            level={'default'}
             text={getLocale('cancel')}
             size={'medium'}
-            type={'accent'}
             onClick={onClose}
           />
           <ActionButton
             level={'primary'}
-            type={'accent'}
             text={getLocale('restore')}
             size={'medium'}
             onClick={this.onRestore}

--- a/src/features/rewards/modalRedirect/index.tsx
+++ b/src/features/rewards/modalRedirect/index.tsx
@@ -34,7 +34,7 @@ export default class ModalRedirect extends React.PureComponent<Props, {}> {
 
     return (
       <StyledButton>
-        <Button onClick={onClick} text={buttonText} type={'accent'} />
+        <Button onClick={onClick} text={buttonText} level={'primary'} />
       </StyledButton>
     )
   }

--- a/src/features/rewards/modalVerify/index.tsx
+++ b/src/features/rewards/modalVerify/index.tsx
@@ -106,7 +106,7 @@ export default class ModalVerify extends React.PureComponent<Props, {}> {
               <StyledButton
                 text={getLocale('walletVerificationButton')}
                 size={'call-to-action'}
-                type={'accent'}
+                level={'primary'}
                 onClick={onVerifyClick}
                 id={'on-boarding-verify-button'}
               />

--- a/src/features/rewards/walletWrapper/index.tsx
+++ b/src/features/rewards/walletWrapper/index.tsx
@@ -56,6 +56,9 @@ import {
   CaratCircleRightIcon
 } from '../../../components/icons'
 
+import { ThemeProvider } from '../../../theme'
+import braveDarkTheme from '../../../theme/brave-dark'
+
 import giftIconUrl from './assets/gift.svg'
 import loveIconUrl from './assets/love.svg'
 import megaphoneIconUrl from './assets/megaphone.svg'
@@ -313,7 +316,6 @@ export default class WalletWrapper extends React.PureComponent<Props, State> {
     return (
       <StyledButton
         size={'small'}
-        type={'accent'}
         level={'primary'}
         onClick={buttonAction}
         text={buttonText}
@@ -357,7 +359,6 @@ export default class WalletWrapper extends React.PureComponent<Props, State> {
       case 'unverified':
         return (
           <Button
-            type={'accent'}
             icon={{
               image: <CaratCircleRightIcon />,
               position: 'after'
@@ -390,7 +391,6 @@ export default class WalletWrapper extends React.PureComponent<Props, State> {
       case 'connected':
         return (
           <Button
-            type={'accent'}
             icon={{
               image: <CaratDownIcon />,
               position: 'after'
@@ -407,7 +407,6 @@ export default class WalletWrapper extends React.PureComponent<Props, State> {
         return (
           <Button
             text={getLocale('walletButtonDisconnected')}
-            type={'subtle'}
             icon={{
               image: <UpholdSystemIcon />,
               position: 'before'
@@ -671,14 +670,15 @@ export default class WalletWrapper extends React.PureComponent<Props, State> {
                     {
                       hasGrants
                         ? <StyleGrantButton>
-                          <Button
-                            text={getLocale('grants')}
-                            size={'small'}
-                            type={'subtle'}
-                            level={'secondary'}
-                            onClick={this.toggleGrantDetails}
-                            icon={{ position: 'after', image: this.state.grantDetails ? <CaratUpIcon /> : <CaratDownIcon /> }}
-                          />
+                          <ThemeProvider theme={braveDarkTheme}>
+                            <Button
+                              text={getLocale('grants')}
+                              size={'small'}
+                              brand={'rewards'}
+                              onClick={this.toggleGrantDetails}
+                              icon={{ position: 'after', image: this.state.grantDetails ? <CaratUpIcon /> : <CaratDownIcon /> }}
+                            />
+                          </ThemeProvider>
                         </StyleGrantButton>
                         : null
                     }

--- a/src/features/rewards/welcomePage/index.tsx
+++ b/src/features/rewards/welcomePage/index.tsx
@@ -245,7 +245,6 @@ class WelcomePage extends React.PureComponent<Props, {}> {
                   </StyledAlertLeft>
                   <Button
                     level={'primary'}
-                    type={'accent'}
                     text={getLocale('walletFailedButton')}
                     onClick={this.props.onReTry}
                   />

--- a/src/features/shields/display.ts
+++ b/src/features/shields/display.ts
@@ -3,8 +3,6 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import styled from '../../theme'
-import Button, { Props as ButtonProps } from '../../components/buttonsIndicators/button'
-import { ComponentType } from 'react'
 
 /**
  * Header
@@ -191,19 +189,4 @@ export const DisabledContentText = styled<{}, 'div'>('div')`
   font-size: 12px;
   font-weight: normal;
   line-height: 18px;
-`
-
-/**
- * button
- */
-export const ShieldsButton = styled(Button as ComponentType<ButtonProps>)`
-  &:focus {
-    outline-offset: 2px;
-    outline-color: ${p => p.theme.color.brandBrave};
-    outline-width: 2px;
-  }
-
-  &:active {
-    outline: none;
-  }
 `

--- a/src/features/shields/index.ts
+++ b/src/features/shields/index.ts
@@ -66,8 +66,7 @@ export {
   // Footer
   Link,
   // Disabled state
-  DisabledContentText,
-  ShieldsButton
+  DisabledContentText
 } from './display'
 
 export { ArrowDownIcon, ArrowUpIcon, ShieldIcon, WarningIcon } from './media'

--- a/src/features/shields/structure/index.ts
+++ b/src/features/shields/structure/index.ts
@@ -410,7 +410,7 @@ export const BlockedListItemSummary = styled(BlockedListItemWithOptions.withComp
 
 export const BlockedListFooter = styled<{}, 'footer'>('footer')`
   box-sizing: border-box;
-  padding: 8px 0px;
+  padding: 12px 0px;
   display: flex;
   justify-content: center;
 `

--- a/src/features/welcome/button/index.ts
+++ b/src/features/welcome/button/index.ts
@@ -4,7 +4,6 @@
 
 import { ComponentType } from 'react'
 import styled, { css } from '../../../theme'
-import Button, { Props as ButtonProps } from '../../../components/buttonsIndicators/button'
 
 interface BaseButtonProps {
   active?: boolean
@@ -20,43 +19,6 @@ const BaseButton = styled<BaseButtonProps, 'button'>('button')`
   border: none;
   cursor: pointer;
   outline: inherit;
-`
-
-export const FooterButton = styled(Button as ComponentType<ButtonProps>)`
-  outline: none;
-  border: 1px solid ${p => p.theme.palette.grey400};
-  color: ${p => p.theme.color.text};
-
-  &:hover {
-    opacity: .9;
-  }
-
-  &:focus {
-    box-shadow: 0 0 0 2px rgba(255,80,0,0.2);
-  }
-`
-
-export const SkipButton = styled(BaseButton)`
-  color: ${p => p.theme.color.text};
-  text-decoration: underline;
-  font-weight: 300;
-  letter-spacing: 0;
-
-  &:hover {
-    opacity: .9;
-  }
-`
-
-export const PrimaryButton = styled(Button as ComponentType<ButtonProps>)`
-  outline: none;
-
-  &:hover {
-    opacity: .9;
-  }
-
-  &:focus {
-    box-shadow: 0 0 0 2px rgba(255,80,0,0.2);
-  }
 `
 
 export const Bullet = styled(BaseButton as ComponentType<any>)`

--- a/src/features/welcome/index.ts
+++ b/src/features/welcome/index.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { SkipButton, FooterButton, Bullet, PrimaryButton } from './button'
+import { Bullet } from './button'
 import { Title, Paragraph } from './text'
 import { SelectBox } from './select'
 import {
@@ -18,9 +18,6 @@ import {
 } from './wrapper'
 
 export {
-  SkipButton,
-  PrimaryButton,
-  FooterButton,
   Bullet,
   Title,
   Paragraph,

--- a/src/theme/brave-dark.ts
+++ b/src/theme/brave-dark.ts
@@ -8,7 +8,9 @@ const darkTheme: ITheme = {
   color: {
     ...defaultTheme.color,
     contextMenuBackground: colors.black,
-    contextMenuForeground: colors.white
+    contextMenuForeground: colors.white,
+    defaultControl: colors.white,
+    defaultButtonBorder: colors.grey400
   }
 }
 

--- a/src/theme/brave-default.ts
+++ b/src/theme/brave-default.ts
@@ -1,5 +1,6 @@
 import colors from './colors'
 import ITheme from './theme-interface'
+import tinyColor from '@ctrl/tinycolor'
 
 // Define colors, fonts, and sizes by purpose.
 // Keys should not describe the value, but what they are to be used for.
@@ -13,13 +14,23 @@ const theme: ITheme = {
     brandBrave: colors.orange500,
     brandBat: colors.blurple500,
     // brave controls
-    brandBraveInteracting: colors.orange500,
+    brandBraveSubtleBackground: tinyColor(colors.orange500).setAlpha(.1).toHex8String(),
+    brandBraveHover: colors.orange300,
+    brandBraveMain: colors.orange400,
+    brandBravePressed: colors.orange500,
+    brandBraveOutline: tinyColor(colors.orange400).setAlpha(.4).toHex8String(),
     brandBraveActive: colors.orange200,
-    brandBraveLight: colors.orange000,
     // bat controls
+    brandBatSubtleBackground: tinyColor(colors.blurple500).setAlpha(.1).toHex8String(),
+    brandBatHover: colors.blurple300,
+    brandBatMain: colors.blurple400,
+    brandBatPressed: colors.blurple500,
+    brandBatOutline: tinyColor(colors.blurple400).setAlpha(.4).toHex8String(),
     brandBatInteracting: colors.blurple500,
     brandBatActive: colors.blurple200,
     // regular controls
+    defaultButtonText: colors.grey800,
+    defaultButtonBorder: colors.grey400,
     defaultControl: colors.grey800,
     defaultControlInteracting: colors.black,
     defaultControlActive: colors.grey700,

--- a/src/theme/theme-interface.ts
+++ b/src/theme/theme-interface.ts
@@ -6,10 +6,18 @@ export default interface IThemeProps {
   color: {
     contextMenuBackground: string
     contextMenuForeground: string
+    brandBraveSubtleBackground: string
+    brandBraveHover: string
+    brandBraveMain: string
+    brandBravePressed: string
+    brandBraveOutline: string
     brandBrave: string
-    brandBraveInteracting: string
     brandBraveActive: string
-    brandBraveLight: string
+    brandBatSubtleBackground: string
+    brandBatHover: string
+    brandBatMain: string
+    brandBatPressed: string
+    brandBatOutline: string
     brandBat: string
     brandBatInteracting: string
     brandBatActive: string
@@ -19,6 +27,8 @@ export default interface IThemeProps {
     primaryBackground: string
     secondaryBackground: string
     modalOverlayBackground: string
+    defaultButtonText: string
+    defaultButtonBorder: string
     defaultControl: string
     defaultControlInteracting: string
     defaultControlActive: string

--- a/stories/components/buttonsIndicators.tsx
+++ b/stories/components/buttonsIndicators.tsx
@@ -22,6 +22,9 @@ const ComponentTypes = styled.div`
   flex-direction: row;
   align-items: flex-start;
 `
+const Spacer = styled.div`
+  margin: 80px 0;
+`
 
 const icon = {
   image: <CheckCircleIcon />
@@ -31,64 +34,62 @@ storiesOf('Components', module)
   .add('Button', () => {
     return (
       <div>
-        <Button text='A Button' />
+        <Button text='All defaults' />
+        <Spacer />
         <ComponentTypes>
+          <Button level='default' text='Default' />
           <Button level='primary' text='Primary' />
           <Button level='secondary' text='Secondary' />
           <Button level='tertiary' text='Tertiary' />
         </ComponentTypes>
+        <Spacer />
         <ComponentTypes>
-          <Button level='primary' type='default' text='Default' />
-          <Button level='primary' type='accent' text='Accent' />
-          <Button level='primary' type='warn' text='Warn' />
-          <Button level='primary' type='subtle' text='Subtle' />
-          <Button level='primary' type='accent' text='Disabled' disabled={true} />
+          <Button level='default' text='Default' />
+          <Button level='default' text='Rewards' brand='rewards' />
+          <Button level='default' text='Disabled' disabled={true} />
+          <Button level='default' text='Disabled' brand='rewards' disabled={true} />
         </ComponentTypes>
         <ComponentTypes>
-          <Button level='secondary' type='default' text='Default' />
-          <Button level='secondary' type='accent' text='Accent' />
-          <Button level='secondary' type='warn' text='Warn' />
-          <Button level='secondary' type='subtle' text='Subtle' />
-          <Button level='secondary' type='accent' text='Disabled' disabled={true} />
+          <Button level='primary' text='Default' />
+          <Button level='primary' text='Rewards' brand='rewards' />
+          <Button level='primary' text='Disabled' disabled={true} />
+          <Button level='primary' text='Disabled' brand='rewards' disabled={true} />
         </ComponentTypes>
         <ComponentTypes>
-          <Button level='tertiary' type='default' text='Default' />
-          <Button level='tertiary' type='accent' text='Accent' />
-          <Button level='tertiary' type='warn' text='Warn' />
-          <Button level='tertiary' type='subtle' text='Subtle' />
-          <Button level='tertiary' type='accent' text='Disabled' disabled={true} />
+          <Button level='secondary' text='Default' />
+          <Button level='secondary' text='Rewards' brand='rewards' />
+          <Button level='secondary' text='Disabled' disabled={true} />
+          <Button level='secondary' text='Disabled' brand='rewards' disabled={true} />
         </ComponentTypes>
         <ComponentTypes>
-          <Button level='primary' type='accent' text='Brave' />
-          <Button level='primary' type='accent' brand='rewards' text='Rewards' />
+          <Button level='tertiary' text='Default' />
+          <Button level='tertiary' text='Rewards' brand='rewards' />
+          <Button level='tertiary' text='Disabled' disabled={true} />
+          <Button level='tertiary' text='Disabled' brand='rewards' disabled={true} />
+        </ComponentTypes>
+        <Spacer />
+        <ComponentTypes>
+          <Button size='small' level='default' text='Small' />
+          <Button size='medium' level='default' text='Medium' />
+          <Button size='large' level='default' text='Large' />
+        </ComponentTypes>
+        <Button size='call-to-action' level='default' text='Call to Action' />
+        <ComponentTypes>
+          <Button size='small' level='primary' text='Small' />
+          <Button size='medium' level='primary' text='Medium' />
+          <Button size='large' level='primary' text='Large' />
+        </ComponentTypes>
+        <Button size='call-to-action' level='primary' text='Call to Action' />
+        <Spacer />
+        <ComponentTypes>
+          <Button icon={{ ...icon, position: 'before' }} size='small' level='primary' text='Small' />
+          <Button icon={{ ...icon, position: 'before' }} size='medium' level='primary' text='Medium' />
+          <Button icon={{ ...icon, position: 'before' }} size='large' level='primary' text='Large' />
         </ComponentTypes>
         <ComponentTypes>
-          <Button size='small' level='primary' type='default' text='Small' />
-          <Button size='medium' level='primary' type='accent' text='Medium' />
-          <Button size='large' level='primary' type='warn' text='Large' />
-        </ComponentTypes>
-        <Button size='call-to-action' level='primary' type='subtle' text='Call to Action' />
-        <ComponentTypes>
-          <Button size='small' level='secondary' type='default' text='Small' />
-          <Button size='medium' level='secondary' type='accent' text='Medium' />
-          <Button size='large' level='secondary' type='warn' text='Large' />
-        </ComponentTypes>
-        <Button size='call-to-action' level='secondary' type='subtle' text='Call to Action' />
-        <ComponentTypes>
-          <Button size='small' level='tertiary' type='default' text='Small' />
-          <Button size='medium' level='tertiary' type='accent' text='Medium' />
-          <Button size='large' level='tertiary' type='warn' text='Large' />
-        </ComponentTypes>
-        <Button size='call-to-action' level='tertiary' type='subtle' text='Call to Action' />
-        <ComponentTypes>
-          <Button icon={{ ...icon, position: 'before' }} size='small' level='primary' type='default' text='Small' />
-          <Button icon={{ ...icon, position: 'before' }} size='medium' level='primary' type='accent' text='Medium' />
-          <Button icon={{ ...icon, position: 'before' }} size='large' level='primary' type='warn' text='Large' />
-        </ComponentTypes>
-        <ComponentTypes>
-          <Button icon={{ ...icon, position: 'after' }} size='small' level='secondary' type='default' text='Small' />
-          <Button icon={{ ...icon, position: 'after' }} size='medium' level='secondary' type='accent' text='Medium' />
-          <Button icon={{ ...icon, position: 'after' }} size='large' level='secondary' type='warn' text='Large' />
+          <Button icon={{ ...icon, position: 'after' }} size='small' level='default' text='Small' />
+          <Button icon={{ ...icon, position: 'after' }} size='medium' level='default' text='Medium' />
+          <Button icon={{ ...icon, position: 'after' }} size='large' level='default' text='Large' />
         </ComponentTypes>
       </div>
     )

--- a/stories/features/shields/components/advancedView/overlays/noScriptOverlay.tsx
+++ b/stories/features/shields/components/advancedView/overlays/noScriptOverlay.tsx
@@ -31,9 +31,11 @@ import {
   SiteInfoText,
   BlockedListSummaryText,
   BlockedListItemHeaderStats,
-  BlockedListItemHeaderText,
-  ShieldsButton
+  BlockedListItemHeaderText
 } from '../../../../../../src/features/shields'
+
+// Shared components
+import Button from '../../../../../../src/components/buttonsIndicators/button'
 
 // Helpers
 import { getLocale } from '../../../fakeLocale'
@@ -120,7 +122,7 @@ export default class CoreFeature extends React.PureComponent<Props, {}> {
           </BlockedListDynamic>
         </details>
         <BlockedListFooter>
-          <ShieldsButton level='primary' type='accent' onClick={onClose} text={getLocale('goBack')} />
+          <Button level='primary' onClick={onClose} text={getLocale('goBack')} />
         </BlockedListFooter>
       </BlockedListContent>
     )

--- a/stories/features/shields/components/advancedView/overlays/staticOverlay.tsx
+++ b/stories/features/shields/components/advancedView/overlays/staticOverlay.tsx
@@ -14,12 +14,14 @@ import {
   Favicon,
   SiteInfoText,
   BlockedInfoRowStats,
-  BlockedListSummaryText,
-  ShieldsButton
+  BlockedListSummaryText
 } from '../../../../../../src/features/shields'
 
 // Group components
 import StaticResourcesList from '../../shared/resourcesBlockedList/staticResourcesList'
+
+// Shared components
+import Button from '../../../../../../src/components/buttonsIndicators/button'
 
 // Fake data
 import { getLocale } from '../../../fakeLocale'
@@ -53,7 +55,7 @@ export default class StaticList extends React.PureComponent<Props, {}> {
             </BlockedListStatic>
         </details>
         <BlockedListFooter>
-          <ShieldsButton level='primary' type='accent' onClick={onClose} text={getLocale('goBack')} />
+          <Button level='primary' onClick={onClose} text={getLocale('goBack')} />
         </BlockedListFooter>
       </BlockedListContent>
     )

--- a/stories/features/shields/components/advancedView/overlays/webCompatWarningOverlay.tsx
+++ b/stories/features/shields/components/advancedView/overlays/webCompatWarningOverlay.tsx
@@ -9,11 +9,11 @@ import {
   Overlay,
   WarningModal,
   WarningIcon,
-  WarningText,
-  ShieldsButton
+  WarningText
 } from '../../../../../../src/features/shields'
 
 // Shared components
+import Button from '../../../../../../src/components/buttonsIndicators/button'
 import { Card } from '../../../../../../src/components'
 
 // Helpers
@@ -34,9 +34,8 @@ export default class WebCompatWarning extends React.PureComponent<Props, {}> {
             <WarningText>
               {getLocale('webCompatWarning')}
             </WarningText>
-            <ShieldsButton
+            <Button
               level='primary'
-              type='accent'
               onClick={onConfirm}
               text={getLocale('gotIt')}
             />

--- a/stories/features/shields/components/readOnlyView/index.tsx
+++ b/stories/features/shields/components/readOnlyView/index.tsx
@@ -14,13 +14,15 @@ import {
   StaticResourcesControls,
   StaticResourcesContainer,
   BlockedInfoRowText,
-  BlockedListFooter,
-  ShieldsButton
+  BlockedListFooter
 } from '../../../../../src/features/shields'
 
 // Group components
 import InterfaceControls from './interfaceControls'
 import PrivacyControls from './privacyControls'
+
+// Shared components
+import Button from '../../../../../src/components/buttonsIndicators/button'
 
 // Helpers
 import { getLocale } from '../../fakeLocale'
@@ -50,7 +52,7 @@ export default class ShieldsReadOnlyView extends React.PureComponent<Props, {}> 
           </StaticResourcesContainer>
         </StaticResourcesControls>
         <BlockedListFooter>
-          <ShieldsButton level='primary' type='accent' onClick={onClose} text={getLocale('goBack')} />
+          <Button level='primary' onClick={onClose} text={getLocale('goBack')} />
         </BlockedListFooter>
       </ShieldsPanel>
     )

--- a/stories/features/sync/disabledContent.tsx
+++ b/stories/features/sync/disabledContent.tsx
@@ -81,13 +81,11 @@ export default class SyncDisabledContent extends React.PureComponent<{}, State> 
                   <DisabledContentButtonGrid>
                     <Button
                       level='primary'
-                      type='accent'
                       onClick={this.onClickNewSyncChainButton}
                       text={getLocale('startSyncChain')}
                     />
                     <Button
-                      level='secondary'
-                      type='accent'
+                      level='default'
                       onClick={this.onClickEnterSyncChainCodeButton}
                       text={getLocale('enterSyncChainCode')}
                     />

--- a/stories/features/sync/enabledContent.tsx
+++ b/stories/features/sync/enabledContent.tsx
@@ -208,14 +208,12 @@ export default class SyncEnabledContent extends React.PureComponent<{}, State> {
                     <br />
                     <Button
                       level='secondary'
-                      type='accent'
                       size='medium'
                       text={getLocale('viewSyncCode')}
                       onClick={this.onClickViewSyncCodeButton}
                     />
                     <Button
                       level='primary'
-                      type='accent'
                       size='medium'
                       text={getLocale('addDevice')}
                       onClick={this.onClickAddDeviceButton}
@@ -231,7 +229,6 @@ export default class SyncEnabledContent extends React.PureComponent<{}, State> {
               <SectionBlock>
                 <Button
                   level='primary'
-                  type='accent'
                   size='medium'
                   text={getLocale('leaveSyncChain')}
                   onClick={this.onClickResetSyncButton}

--- a/stories/features/sync/modals/enterSyncCode.tsx
+++ b/stories/features/sync/modals/enterSyncCode.tsx
@@ -79,8 +79,7 @@ export default class EnterSyncCodeModal extends React.PureComponent<Props, State
         <TwoColumnButtonGrid>
             <OneColumnButtonGrid>
               <Button
-                level='secondary'
-                type='subtle'
+                level='tertiary'
                 size='medium'
                 onClick={onClose}
                 text={getLocale('cancel')}
@@ -88,7 +87,6 @@ export default class EnterSyncCodeModal extends React.PureComponent<Props, State
             </OneColumnButtonGrid>
             <Button
               level='primary'
-              type='accent'
               size='medium'
               onClick={this.onClickConfirmSyncCode}
               text={getLocale('confirmCode')}

--- a/stories/features/sync/modals/removeMainDevice.tsx
+++ b/stories/features/sync/modals/removeMainDevice.tsx
@@ -39,8 +39,7 @@ export default class RemoveMainDeviceModal extends React.PureComponent<Props, {}
         <TwoColumnButtonGrid>
             <OneColumnButtonGrid>
               <Button
-                level='secondary'
-                type='subtle'
+                level='tertiary'
                 size='medium'
                 onClick={onClose}
                 text={getLocale('cancel')}
@@ -48,7 +47,6 @@ export default class RemoveMainDeviceModal extends React.PureComponent<Props, {}
             </OneColumnButtonGrid>
             <Button
               level='primary'
-              type='warn'
               size='medium'
               onClick={onClose}
               text={getLocale('remove')}

--- a/stories/features/sync/modals/removeOtherDevice.tsx
+++ b/stories/features/sync/modals/removeOtherDevice.tsx
@@ -39,8 +39,7 @@ export default class RemoveMainDeviceModal extends React.PureComponent<Props, {}
         <TwoColumnButtonGrid>
           <OneColumnButtonGrid>
             <Button
-              level='secondary'
-              type='subtle'
+              level='tertiary'
               size='medium'
               onClick={onClose}
               text={getLocale('cancel')}
@@ -48,7 +47,6 @@ export default class RemoveMainDeviceModal extends React.PureComponent<Props, {}
           </OneColumnButtonGrid>
           <Button
             level='primary'
-            type='warn'
             size='medium'
             onClick={onClose}
             text={getLocale('remove')}

--- a/stories/features/sync/modals/resetSync.tsx
+++ b/stories/features/sync/modals/resetSync.tsx
@@ -73,8 +73,7 @@ export default class ResetSyncModal extends React.PureComponent<Props, State> {
         <TwoColumnButtonGrid>
             <OneColumnButtonGrid>
               <Button
-                level='secondary'
-                type='subtle'
+                level='tertiary'
                 size='medium'
                 onClick={onClose}
                 text={getLocale('cancel')}
@@ -82,7 +81,6 @@ export default class ResetSyncModal extends React.PureComponent<Props, State> {
             </OneColumnButtonGrid>
             <Button
               level='primary'
-              type='warn'
               size='medium'
               onClick={this.onSetupSync}
               text={getLocale('deleteSyncChainButton')}

--- a/stories/features/sync/modals/scanCode.tsx
+++ b/stories/features/sync/modals/scanCode.tsx
@@ -12,7 +12,6 @@ import {
   ModalHeader,
   Title,
   Paragraph,
-  Link,
   ScanGrid,
   ThreeColumnButtonGrid
 } from '../../../../src/features/sync'
@@ -49,8 +48,7 @@ export default class ScanCodeModal extends React.PureComponent<Props, State> {
     this.setState({ enterCodeWordsInstead: !this.state.enterCodeWordsInstead })
   }
 
-  onCancel = (event: React.MouseEvent<HTMLAnchorElement>) => {
-    event.preventDefault()
+  onCancel = () => {
     this.props.onClose()
   }
 
@@ -76,12 +74,11 @@ export default class ScanCodeModal extends React.PureComponent<Props, State> {
           </ScanGrid>
           <ThreeColumnButtonGrid>
           <div>
-            <Link onClick={this.onCancel}>{getLocale('cancel')}</Link>
+            <Button level='tertiary' onClick={this.onCancel} text={getLocale('cancel')}/>
           </div>
           <div>
             <Button
               level='secondary'
-              type='subtle'
               size='medium'
               onClick={onClose}
               text={getLocale('viewSyncCode')}
@@ -90,7 +87,6 @@ export default class ScanCodeModal extends React.PureComponent<Props, State> {
           <div>
             <Button
               level='primary'
-              type='accent'
               size='medium'
               onClick={onClose}
               text={getLocale('viewCodeWords')}

--- a/stories/features/sync/modals/viewSyncCode.tsx
+++ b/stories/features/sync/modals/viewSyncCode.tsx
@@ -13,7 +13,6 @@ import {
   ModalHeader,
   Title,
   Paragraph,
-  Link,
   Bold,
   ThreeColumnButtonGrid
 } from '../../../../src/features/sync'
@@ -27,8 +26,7 @@ interface Props {
 }
 
 export default class ViewSyncCodeModal extends React.PureComponent<Props, {}> {
-  onCancel = (event: React.MouseEvent<HTMLAnchorElement>) => {
-    event.preventDefault()
+  onCancel = () => {
     this.props.onClose()
   }
   render () {
@@ -51,20 +49,18 @@ export default class ViewSyncCodeModal extends React.PureComponent<Props, {}> {
         />
         <ThreeColumnButtonGrid>
           <div>
-            <Link onClick={this.onCancel}>{getLocale('cancel')}</Link>
+            <Button level='tertiary' onClick={this.onCancel} text={getLocale('cancel')}/>
           </div>
           <div>
             <Button
               level='secondary'
-              type='subtle'
               size='medium'
               onClick={onClose}
               text={getLocale('qrCode')}
             />
           </div>
           <Button
-            level='secondary'
-            type='accent'
+            level='primary'
             size='medium'
             onClick={onClose}
             disabled={true}

--- a/stories/features/welcome/page/screens/footerBox.tsx
+++ b/stories/features/welcome/page/screens/footerBox.tsx
@@ -10,12 +10,11 @@ import {
   FooterLeftColumn,
   FooterMiddleColumn,
   FooterRightColumn,
-  SkipButton,
-  FooterButton,
   Bullet
 } from '../../../../../src/features/welcome/'
 
 // Shared components
+import Button from '../../../../../src/components/buttonsIndicators/button'
 import { ArrowRightIcon } from '../../../../../src/components/icons'
 
 // Utils
@@ -36,7 +35,7 @@ export default class FooterBox extends React.PureComponent<Props, {}> {
     return (
       <Footer>
         <FooterLeftColumn>
-          <SkipButton onClick={onClickSkip}>{locale.skipWelcomeTour}</SkipButton>
+          <Button level={'tertiary'} size={'small'} onClick={onClickSkip} text={locale.skipWelcomeTour} />
         </FooterLeftColumn>
         <FooterMiddleColumn>
           {Array.from({ length: totalScreensSize }, (v: undefined, k: number) => (
@@ -49,9 +48,8 @@ export default class FooterBox extends React.PureComponent<Props, {}> {
             // don't show the next button in the first screen
             currentScreen !== 1
               ? (
-                <FooterButton
-                  level='secondary'
-                  type='default'
+                <Button
+                  level='default'
                   size='medium'
                   onClick={onClickNext}
                   text={locale.next}
@@ -59,9 +57,8 @@ export default class FooterBox extends React.PureComponent<Props, {}> {
                 />
               )
               : currentScreen !== 1 && (
-                <FooterButton
-                  level='secondary'
-                  type='default'
+                <Button
+                  level='default'
                   size='medium'
                   onClick={onClickDone}
                   text={locale.done}

--- a/stories/features/welcome/page/screens/importBox.tsx
+++ b/stories/features/welcome/page/screens/importBox.tsx
@@ -5,8 +5,11 @@
 import * as React from 'react'
 
 // Feature-specific components
-import { Content, Title, Paragraph, PrimaryButton, SelectGrid } from '../../../../../src/features/welcome/'
+import { Content, Title, Paragraph, SelectGrid } from '../../../../../src/features/welcome/'
 import { SelectBox } from '../../../../../src/features/welcome'
+
+// Shared components
+import Button from '../../../../../src/components/buttonsIndicators/button'
 
 // Utils
 import locale from '../fakeLocale'
@@ -59,9 +62,8 @@ export default class ImportBox extends React.PureComponent<Props, State> {
                 <option value='Chrome'>{locale.fakeBrowser1}</option>
                 <option value='Firefox'>{locale.fakeBrowser2}</option>
               </SelectBox>
-              <PrimaryButton
+              <Button
                 level='primary'
-                type='accent'
                 size='large'
                 text={locale.import}
                 disabled={!importSelected}

--- a/stories/features/welcome/page/screens/rewardsBox.tsx
+++ b/stories/features/welcome/page/screens/rewardsBox.tsx
@@ -5,7 +5,10 @@
 import * as React from 'react'
 
 // Feature-specific components
-import { Content, Title, Paragraph, PrimaryButton } from '../../../../../src/features/welcome/'
+import { Content, Title, Paragraph } from '../../../../../src/features/welcome/'
+
+// Shared components
+import Button from '../../../../../src/components/buttonsIndicators/button'
 
 // Utils
 import locale from '../fakeLocale'
@@ -32,9 +35,8 @@ export default class PaymentsBox extends React.PureComponent<Props, {}> {
         <WelcomeRewardsImage />
         <Title>{locale.enableBraveRewards}</Title>
         <Paragraph>{locale.setupBraveRewards}</Paragraph>
-        <PrimaryButton
+        <Button
           level='primary'
-          type='accent'
           size='large'
           text={locale.getStarted}
           onClick={onClick}

--- a/stories/features/welcome/page/screens/searchBox.tsx
+++ b/stories/features/welcome/page/screens/searchBox.tsx
@@ -6,8 +6,11 @@
 import * as React from 'react'
 
 // Feature-specific components
-import { Content, Title, Paragraph, SelectGrid, PrimaryButton } from '../../../../../src/features/welcome/'
+import { Content, Title, Paragraph, SelectGrid } from '../../../../../src/features/welcome/'
 import { SelectBox } from '../../../../../src/features/welcome'
+
+// Shared components
+import Button from '../../../../../src/components/buttonsIndicators/button'
 
 // Utils
 import locale from '../fakeLocale'
@@ -61,9 +64,8 @@ export default class SearchEngineBox extends React.PureComponent<Props, State> {
               <option value='DuckDuckGo'>{locale.fakeSearchProvider1}</option>
               <option value='Google'>{locale.fakeSearchProvider2}</option>
             </SelectBox>
-            <PrimaryButton
+            <Button
               level='primary'
-              type='accent'
               size='large'
               text={locale.setDefault}
               disabled={!searchEngineSelected}

--- a/stories/features/welcome/page/screens/themeBox.tsx
+++ b/stories/features/welcome/page/screens/themeBox.tsx
@@ -5,8 +5,11 @@
 import * as React from 'react'
 
 // Feature-specific components
-import { Content, Title, Paragraph, PrimaryButton, SelectGrid } from '../../../../../src/features/welcome/'
+import { Content, Title, Paragraph, SelectGrid } from '../../../../../src/features/welcome/'
 import { SelectBox } from '../../../../../src/features/welcome'
+
+// Shared components
+import Button from '../../../../../src/components/buttonsIndicators/button'
 
 // Utils
 import locale from '../fakeLocale'
@@ -61,9 +64,8 @@ export default class ThemingBox extends React.PureComponent<Props, State> {
               <option value='Dark'>{locale.themeOption2}</option>
               <option value='System'>{locale.themeOption3}</option>
             </SelectBox>
-            <PrimaryButton
+            <Button
               level='primary'
-              type='accent'
               size='large'
               text={locale.confirm}
               disabled={!themeSelected}

--- a/stories/features/welcome/page/screens/welcomeBox.tsx
+++ b/stories/features/welcome/page/screens/welcomeBox.tsx
@@ -5,9 +5,10 @@
 import * as React from 'react'
 
 // Feature-specific components
-import { Content, Title, Paragraph, PrimaryButton } from '../../../../../src/features/welcome/'
+import { Content, Title, Paragraph } from '../../../../../src/features/welcome/'
 
 // Shared components
+import Button from '../../../../../src/components/buttonsIndicators/button'
 import { ArrowRightIcon } from '../../../../../src/components/icons'
 
 // Utils
@@ -35,9 +36,8 @@ export default class ThemingBox extends React.PureComponent<Props, {}> {
         <WelcomeLionImage />
         <Title>{locale.welcome}</Title>
         <Paragraph>{locale.whatIsBrave}</Paragraph>
-        <PrimaryButton
+        <Button
           level='primary'
-          type='accent'
           size='large'
           text={locale.letsGo}
           onClick={onClick}


### PR DESCRIPTION
## Changes

Fixes #536.

Addresses concerns from #486 as well.

With this PR, buttons are all themed using a common `Button` component, and have a visual update as described in #536.

This will require changes in https://github.com/brave/brave-core wherever buttons are used as well.

## Test plan

Storybook stories and snapshots have been updated to use the new buttons. I've done a scan through all of the usages of buttons to verify that everything looks acceptable, but another pair of eyes would be appreciated.

##### Link / storybook path to visual changes
- Primarily http://localhost:9091/?path=/story/components--button, but most of the stories include some kind of button and have also been updated accordingly.

<!-- can be localhost storybook or `now` deployment -->

## Integration
- [x] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [x] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [x] Does this contain changes to src/features for brave-core?
  - [x] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [ ] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
