### PR TITLE
Make dark theme more useful

### DIFF
--- a/src/components/layout/card/__snapshots__/spec.tsx.snap
+++ b/src/components/layout/card/__snapshots__/spec.tsx.snap
@@ -6,7 +6,7 @@ exports[`card tests basic tests matches the snapshot 1`] = `
   width: 100%;
   min-height: auto;
   margin: 0;
-  background-color: #fff;
+  background-color: #FFFFFF;
   border-radius: 4px;
   box-shadow: 0 2px 4px rgba(0,0,0,.15);
   font-size: inherit;

--- a/src/components/layout/card/style.ts
+++ b/src/components/layout/card/style.ts
@@ -24,7 +24,7 @@ export const Card = styled<StyledCardProps, 'div'>('div')`
   width: 100%;
   min-height: auto;
   margin: 0;
-  background-color: #fff;
+  background-color: ${p => p.theme.color.panelBackground};
   border-radius: 4px;
   box-shadow: ${p => `0 2px 4px rgba(0, 0, 0, ${getShadowOpacity(p.emphasis)})`};
   font-size: inherit;

--- a/src/theme/brave-dark.ts
+++ b/src/theme/brave-dark.ts
@@ -11,7 +11,9 @@ const darkTheme: ITheme = {
     contextMenuForeground: colors.white,
     defaultControl: colors.grey400,
     defaultControlInteracting: colors.white,
-    defaultControlActive: colors.grey500
+    defaultControlActive: colors.grey500,
+    panelBackground: colors.grey900,
+    text: colors.white
   }
 }
 


### PR DESCRIPTION
## Changes

This adds some generic color overrides that should be useful for most browser components in dark mode: text, panel colors, and button colors.

I've tweaked the `Card` component to use the `panelBackground` theme color since it's also required to be able to theme the webcompat reporter dialog.

## Test plan


##### Link / storybook path to visual changes
- 
<!-- can be localhost storybook or `now` deployment -->

## Integration
- [x] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [ ] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [ ] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
