### PR TITLE
allow any kind of theme for themeProvider and helper methods

### DIFF
--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -1,7 +1,7 @@
 // @ts-ignore: Needed for ThemeProvider
 import * as React from 'react'
 import * as styledComponents from 'styled-components'
-import IThemeProps, { BraveThemedStyledProps as ThemedStyledProps } from './theme-interface'
+import { BraveThemedStyledProps as ThemedStyledProps } from './theme-interface'
 // theme for testing
 import TestTheme from './brave-default'
 
@@ -17,7 +17,7 @@ const {
   //   see: https://github.com/palantir/tslint/issues/3505
   //   It's possibly due to the rule upstream in tslint-config-standard
   // tslint:disable-next-line
-} = styledComponents as styledComponents.ThemedStyledComponentsModule<IThemeProps>
+} = styledComponents as styledComponents.ThemedStyledComponentsModule<any>
 
 export default styled
 


### PR DESCRIPTION
This allows `ThemedStyledComponentsModule` to receive any theme as a prop. Needed for https://github.com/brave/brave-core/pull/3300.

The reasoning I had is that we can type feature-specific themes in there instead of forcing a theme in root level. I'm open for discussion regarding better options.