### PR TITLE
Don't store currently selected option ReactNode in state

### DIFF
--- a/src/components/formControls/select/index.tsx
+++ b/src/components/formControls/select/index.tsx
@@ -38,7 +38,6 @@ export interface Props {
 
 interface State {
   value: string | number
-  selected: React.ReactNode
   show: boolean
   radioShown: boolean
 }
@@ -58,10 +57,8 @@ export default class Select extends React.PureComponent<Props, State> {
   constructor (props: Props) {
     super(props)
 
-    const obj = this.getDefaultValue(props)
     this.state = {
-      value: obj.value,
-      selected: obj.selected,
+      value: this.getDefaultValue(props).value,
       show: false,
       radioShown: false
     }
@@ -73,10 +70,8 @@ export default class Select extends React.PureComponent<Props, State> {
 
   componentDidUpdate (prevProps: Props) {
     if (prevProps.value !== this.props.value) {
-      const obj = this.getDefaultValue(this.props)
       this.setState({
-        value: obj.value,
-        selected: obj.selected,
+        value: this.getDefaultValue(this.props).value,
         show: false
       })
     }
@@ -127,7 +122,6 @@ export default class Select extends React.PureComponent<Props, State> {
   onRadioOptionClick = (key: string, selected: boolean, child: React.ReactNode, all: {[key: string]: boolean}) => {
     this.setState({
       value: key,
-      selected: child,
       radioShown: false
     })
 
@@ -193,7 +187,7 @@ export default class Select extends React.PureComponent<Props, State> {
         <StyledOption
           showAllContents={showAllContents}
           key={`${self.props.id}-option-${i}`}
-          onClick={self.onOptionClick.bind(self, value, child, element)}
+          onClick={self.onOptionClick.bind(self, value, child)}
           selected={selected}
         >
           <StyledOptionCheck>
@@ -204,10 +198,9 @@ export default class Select extends React.PureComponent<Props, State> {
     })
   }
 
-  onOptionClick = (value: string, child: React.ReactNode, element: React.ReactNode) => {
+  onOptionClick = (value: string, child: React.ReactNode) => {
     this.setState({
       value: value,
-      selected: element,
       show: false
     })
 
@@ -262,7 +255,7 @@ export default class Select extends React.PureComponent<Props, State> {
               floating={floating}
             >
               <StyledSelectText floating={floating}>
-                {this.state.selected}
+                {this.getDefaultValue(this.props).selected}
               </StyledSelectText>
               <StyledSelectArrow floating={floating}>
                 <CaratDownIcon />


### PR DESCRIPTION
Resolves #560

## Changes

Currently, the rendered node corresponding to the selected option is stored in state and then used during render. This means that we can be displaying a react node that no longer corresponds to one of the select component's children. Instead of storing the rendered node in state, simply recompute the "selected" node on each render.

## Test plan


##### Link / storybook path to visual changes
- 
<!-- can be localhost storybook or `now` deployment -->

## Integration
- [ ] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [ ] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [ ] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
