### PR TITLE
Update getLocale to support square-bracket replacement patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,8 @@
       "!src/**/index.ts"
     ],
     "testMatch": [
-      "<rootDir>/src/**/spec.tsx"
+      "<rootDir>/src/**/spec.tsx",
+      "<rootDir>/src/**/*.test.ts"
     ],
     "testPathIgnorePatterns": [
       "<rootDir>/node_modules/"

--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this file,
+* You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { initLocale, getLocale } from './helpers'
+
+test('getLocale', () => {
+  initLocale({
+    msg: 'Hello [[ name]] from {{world }}'
+  })
+
+  expect(getLocale('msg', { name: 'Alice', world: 'Earth' }))
+    .toBe('Hello Alice from Earth')
+})

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -68,7 +68,8 @@ export const getLocale = (key: string, replacements?: Replacements) => {
   }
 
   for (let item in replacements) {
-    returnVal = returnVal.replace(new RegExp('{{\\s*' + item + '\\s*}}', 'g'), replacements[item].toString())
+    const reString = String.raw`({{\s*${item}\s*}})|(\[\[\s*${item}\s*\]\])`
+    returnVal = returnVal.replace(new RegExp(reString, 'g'), replacements[item].toString())
   }
   return returnVal
 }


### PR DESCRIPTION
When upgrading Brave to Chromium 90 message replacement patterns were changed from using curly braces to square brackets. This change adds support for square bracket message patterns. Eventually all messages should be reconfigured to use appropriate placeholders instead of delimited patterns.

## Changes

## Test plan


##### Link / storybook path to visual changes
- 
<!-- can be localhost storybook or `now` deployment -->

## Integration
- [ ] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [ ] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [ ] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
