### PR TITLE
Match text color inside Select Component to have less contrast on Dark Theme

### DIFF
--- a/src/components/formControls/select/__snapshots__/spec.tsx.snap
+++ b/src/components/formControls/select/__snapshots__/spec.tsx.snap
@@ -45,8 +45,7 @@ exports[`Select tests basic tests matches the snapshot 1`] = `
   padding: 0 5px 0 13px;
   overflow: hidden;
   white-space: nowrap;
-  --select-text-color: #686978;
-  color: var(--select-text-color);
+  color: 686978;
   text-overflow: ellipsis;
 }
 
@@ -150,6 +149,7 @@ exports[`Select tests basic tests matches the snapshot 1`] = `
     >
       <div
         className="c3"
+        type="light"
       >
         01
       </div>

--- a/src/components/formControls/select/__snapshots__/spec.tsx.snap
+++ b/src/components/formControls/select/__snapshots__/spec.tsx.snap
@@ -45,6 +45,8 @@ exports[`Select tests basic tests matches the snapshot 1`] = `
   padding: 0 5px 0 13px;
   overflow: hidden;
   white-space: nowrap;
+  --select-text-color: #686978;
+  color: var(--select-text-color);
   text-overflow: ellipsis;
 }
 

--- a/src/components/formControls/select/index.tsx
+++ b/src/components/formControls/select/index.tsx
@@ -30,10 +30,15 @@ export interface Props {
   title?: string
   disabled?: boolean
   floating?: boolean
+  theme? : StyleThemeProps
   showAllContents?: boolean
   value?: string
   onChange?: (value: string, child: React.ReactNode) => void
   type?: Type
+}
+
+interface StyleThemeProps extends Props {
+  name? : String
 }
 
 interface State {

--- a/src/components/formControls/select/index.tsx
+++ b/src/components/formControls/select/index.tsx
@@ -259,7 +259,7 @@ export default class Select extends React.PureComponent<Props, State> {
               type={type}
               floating={floating}
             >
-              <StyledSelectText floating={floating}>
+              <StyledSelectText type={type} floating={floating}>
                 {this.getDefaultValue(this.props).selected}
               </StyledSelectText>
               <StyledSelectArrow floating={floating}>

--- a/src/components/formControls/select/style.ts
+++ b/src/components/formControls/select/style.ts
@@ -5,6 +5,22 @@
 import styled, { css } from '../../../theme'
 import { Props } from './index'
 
+const matchTextColorWithTheme = (p: StyleProps) => {
+  let color;
+
+  switch(p.theme?.name){
+    case "Brave Dark": 
+      color = "#B8B9C4";
+      break;
+    case "Default":
+      color = "#686978";
+  }
+
+  return css`
+    --select-text-color : ${color};
+  `
+}
+
 const getSelectColors = (p: StyleProps) => {
   let color = '#686978'
   let borderColor = '#DFDFE8'
@@ -79,6 +95,8 @@ export const StyledSelectText = styled('div')<StyleProps>`
   padding: ${p => p.floating ? 0 : '0 5px 0 13px'};
   overflow: hidden;
   white-space: nowrap;
+  ${matchTextColorWithTheme};
+  color: var(--select-text-color);
   text-overflow: ellipsis;
 `
 

--- a/src/components/formControls/select/style.ts
+++ b/src/components/formControls/select/style.ts
@@ -5,22 +5,6 @@
 import styled, { css } from '../../../theme'
 import { Props } from './index'
 
-const matchTextColorWithTheme = (p: StyleProps) => {
-  let color;
-
-  switch(p.theme?.name){
-    case "Brave Dark": 
-      color = "#B8B9C4";
-      break;
-    case "Default":
-      color = "#686978";
-  }
-
-  return css`
-    --select-text-color : ${color};
-  `
-}
-
 const getSelectColors = (p: StyleProps) => {
   let color = '#686978'
   let borderColor = '#DFDFE8'
@@ -95,8 +79,7 @@ export const StyledSelectText = styled('div')<StyleProps>`
   padding: ${p => p.floating ? 0 : '0 5px 0 13px'};
   overflow: hidden;
   white-space: nowrap;
-  ${matchTextColorWithTheme};
-  color: var(--select-text-color);
+  color: ${p => p.type === 'dark' ? '#B8B9C4' : '686978'};
   text-overflow: ellipsis;
 `
 


### PR DESCRIPTION
## Changes

- Text color inside a Select component was changed in order to reduce contrast for Dark Theme

**Issue relate to:** [Make clock options display better with dark theme](https://github.com/brave/brave-browser/issues/12061)

## Test plan

Changed text color inside the select, so we ensure color showed in the dark theme dropdown will have less contrast when shows options

![image](https://user-images.githubusercontent.com/13340320/110217349-41407380-7e92-11eb-93c8-7c4deafa7c90.png)

## Integration
- [X] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [ ] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [ ] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [ ] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
