### PR TITLE
checkbox: fix tabindex should be number, not string

### DIFF
--- a/src/components/formControls/checkbox/__snapshots__/spec.tsx.snap
+++ b/src/components/formControls/checkbox/__snapshots__/spec.tsx.snap
@@ -143,7 +143,7 @@ exports[`Checkbox tests basic tests matches the snapshot 1`] = `
     role="checkbox"
     selected={true}
     size="small"
-    tabIndex="0"
+    tabIndex={0}
     type="light"
   >
     <span
@@ -178,7 +178,7 @@ exports[`Checkbox tests basic tests matches the snapshot 1`] = `
     role="checkbox"
     selected={false}
     size="small"
-    tabIndex="0"
+    tabIndex={0}
     type="light"
   >
     <span
@@ -202,7 +202,7 @@ exports[`Checkbox tests basic tests matches the snapshot 1`] = `
     role="checkbox"
     selected={false}
     size="small"
-    tabIndex="0"
+    tabIndex={0}
     type="light"
   >
     <span

--- a/src/components/formControls/checkbox/index.tsx
+++ b/src/components/formControls/checkbox/index.tsx
@@ -53,7 +53,7 @@ export default class Checkbox extends React.PureComponent<Props, {}> {
           data-testid={`checkbox-child-${i}`}
           role='checkbox'
           aria-checked={selected ? 'true' : 'false'}
-          tabIndex={self.props.disabled ? undefined : '0'}
+          tabIndex={self.props.disabled ? undefined : 0}
           onClick={!self.props.disabled ? onClick : undefined}
           onKeyPress={!self.props.disabled ? onKeyPressForAction.bind(null, onClick) : undefined}
           type={self.props.type}

--- a/src/components/formControls/checkbox/spec.tsx
+++ b/src/components/formControls/checkbox/spec.tsx
@@ -1,6 +1,5 @@
 /* global jest, expect, describe, it, afterEach */
 import * as React from 'react'
-import { shallow } from 'enzyme'
 import { create } from 'react-test-renderer'
 import '@testing-library/jest-dom'
 import userEvent from '@testing-library/user-event'


### PR DESCRIPTION
## Changes
Tabindex should be number, not string. Fixes brave-core typescript errors when integrating https://github.com/brave/brave-ui/pull/595

## Test plan
unit tests still pass

##### Link / storybook path to visual changes
- 
<!-- can be localhost storybook or `now` deployment -->

## Integration
- [x] Does this contain changes to src/components or src/
  - [ ] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [ ] Incompatible API change to something existing _(major version increase)_
  - [ ] Adding new backwards-compatible functionality? _(minor version increase)_
  - [x] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [ ] Does this contain changes to src/features for brave-core?
  - [ ] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [ ] Will you create brave-core PR to update to this commit after it is merged?
  - [ ] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
