### PR TITLE
Patched 🐛 CVE-2020-7677 made use of unsafe calls to `eval`

### DIFF
--- a/tools/icon-component-generator/package-lock.json
+++ b/tools/icon-component-generator/package-lock.json
@@ -539,8 +539,8 @@
       }
     },
     "thenify": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
       "requires": {
         "any-promise": "^1.0.0"


### PR DESCRIPTION
## Description:
Versions of thenify prior to 3.3.1 made use of unsafe calls to `eval`. Untrusted user input could thus lead to arbitrary code execution on the host. The patch in version 3.3.1 removes calls to `eval`.


on thenify in [tools/icon-component-generator/package-lock.json](https://github.com/brave/brave-ui/blob/-/tools/icon-component-generator/package-lock.json).

**CVE-2020-7677**
`9.8 / 10`
CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
