### PR TITLE
Patched 🐛 Server-Side Request Forgery in parse-url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12083,7 +12083,7 @@
       "dev": true,
       "requires": {
         "is-ssh": "^1.3.0",
-        "parse-url": "^5.0.0"
+        "parse-url": "^6.0.1"
       }
     },
     "git-url-parse": {
@@ -17297,7 +17297,7 @@
       "dev": true
     },
     "parse-url": {
-      "version": "5.0.1",
+      "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.1.tgz",
       "integrity": "sha512-flNUPP27r3vJpROi0/R3/2efgKkyXqnXwyP1KQ2U0SfFRgdizOdWfvrrvJg1LuOoxs7GQhmxJlq23IpQ/BkByg==",
       "dev": true,


### PR DESCRIPTION
## Descriptions:
Server-Side Request Forgery (SSRF) in GitHub repository ionicabizau/parse-url prior to 7.0.0.
on parse-url in [package-lock.json](https://github.com/brave/brave-ui/blob/-/package-lock.json).

**CVE-2022-2216**
`9.8 / 10`
CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
