### PR TITLE
Fixed @ CVE-2020-7677

### DIFF
--- a/tools/icon-component-generator/package-lock.json
+++ b/tools/icon-component-generator/package-lock.json
@@ -539,9 +539,9 @@
       }
     },
     "thenify": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
-      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
       "requires": {
         "any-promise": "^1.0.0"
       }


### PR DESCRIPTION
## Vulnerability Description
Versions of thenify prior to 3.3.1 made use of unsafe calls to eval. Untrusted user input could thus lead to arbitrary code execution on the host. The patch in version 3.3.1 removes calls to eval.

<!-- can be localhost storybook or `now` deployment -->

## Integration
- [x] Does this contain changes to src/components or src/
  - [x] Will you publish to npm immediately after this PR, or wait until sometime in the future?
  - [x] Incompatible API change to something existing _(major version increase)_
  - [x] Adding new backwards-compatible functionality? _(minor version increase)_
  - [x] Fixing a bug backwards-compatibly? _(patch version increase)_
  
- [x] Does this contain changes to src/features for brave-core?
  - [x] Are there non backwards-compatible changes required for brave-core? **Do not merge until brave-core PR is approvable.** Link to brave-core PR:
  - [x] Will you create brave-core PR to update to this commit after it is merged?
  - [x] Wants uplift to brave-core feature branch?
     - When uplift-approved, merge to brave-core-0.VV.x feature branch
     - Create additional brave-core PRs for each feature branch to update commit
