### PR TITLE
Move all theme variables to a parent property named "legacy"

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -26,7 +26,7 @@ addParameters({
   }
 })
 
-const themes = [DefaultTheme, DarkTheme]
+const themes = [{ name: DefaultTheme.name, legacy: DefaultTheme }, { name: DarkTheme.name, legacy: DarkTheme }]
 addDecorator(withThemesProvider(themes))
 
 function loadStories () {

--- a/definitions/styled-components-theme.d.ts
+++ b/definitions/styled-components-theme.d.ts
@@ -1,0 +1,13 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import IBraveUITheme from '../src/theme/theme-interface'
+
+declare module 'styled-components' {
+  export interface DefaultTheme {
+    // Marked legacy as this repo is deprecated
+    legacy: IBraveUITheme
+  }
+}

--- a/src/components/buttonsIndicators/button/style.ts
+++ b/src/components/buttonsIndicators/button/style.ts
@@ -25,34 +25,34 @@ const getThemeColors = (p: StyledProps<Props>) => {
   let hoverColor
   let activeColor
   if (p.disabled) {
-    mainColor = hoverColor = activeColor = p.theme.color.disabled
+    mainColor = hoverColor = activeColor = p.theme.legacy.color.disabled
   } else {
     switch (p.type) {
       case 'accent':
         if (p.brand === 'brave') {
-          mainColor = p.theme.color.brandBrave
-          hoverColor = p.theme.color.brandBraveInteracting
-          activeColor = p.theme.color.brandBraveActive
+          mainColor = p.theme.legacy.color.brandBrave
+          hoverColor = p.theme.legacy.color.brandBraveInteracting
+          activeColor = p.theme.legacy.color.brandBraveActive
         } else if (p.brand === 'rewards') {
-          mainColor = p.theme.color.brandBat
-          hoverColor = p.theme.color.brandBatInteracting
-          activeColor = p.theme.color.brandBatActive
+          mainColor = p.theme.legacy.color.brandBat
+          hoverColor = p.theme.legacy.color.brandBatInteracting
+          activeColor = p.theme.legacy.color.brandBatActive
         }
         break
       case 'default':
-        mainColor = p.theme.color.defaultControl
-        hoverColor = p.theme.color.defaultControlInteracting
-        activeColor = p.theme.color.defaultControlActive
+        mainColor = p.theme.legacy.color.defaultControl
+        hoverColor = p.theme.legacy.color.defaultControlInteracting
+        activeColor = p.theme.legacy.color.defaultControlActive
         break
       case 'warn':
-        mainColor = p.theme.color.warn
-        hoverColor = p.theme.color.warnInteracting
-        activeColor = p.theme.color.warnActive
+        mainColor = p.theme.legacy.color.warn
+        hoverColor = p.theme.legacy.color.warnInteracting
+        activeColor = p.theme.legacy.color.warnActive
         break
       case 'subtle':
-        mainColor = p.theme.color.subtle
-        hoverColor = p.theme.color.subtleInteracting
-        activeColor = p.theme.color.subtleActive
+        mainColor = p.theme.legacy.color.subtle
+        hoverColor = p.theme.legacy.color.subtleInteracting
+        activeColor = p.theme.legacy.color.subtleActive
         break
     }
   }

--- a/src/components/dataTables/table/style.ts
+++ b/src/components/dataTables/table/style.ts
@@ -20,7 +20,7 @@ export const StyledTable = styled('table')<{}>`
 export const StyledTH = styled('th')<Partial<Cell>>`
   text-transform: uppercase;
   text-align: left;
-  font-family: ${p => p.theme.fontFamily.body};
+  font-family: ${p => p.theme.legacy.fontFamily.body};
   font-size: 12px;
   font-weight: 500;
   border-bottom: 2px solid #dedfe4;

--- a/src/components/formControls/checkbox/style.ts
+++ b/src/components/formControls/checkbox/style.ts
@@ -53,7 +53,7 @@ const getLabelProps = (p: Partial<StyleProps>) => {
 
 export const StyledLabel = styled('label')<Partial<StyleProps>>`
   ${getLabelProps};
-  font-family: ${p => p.theme.fontFamily.body};
+  font-family: ${p => p.theme.legacy.fontFamily.body};
   display: flex;
   align-items: center;
   margin-bottom: 4px;

--- a/src/components/formControls/controlWrapper/style.ts
+++ b/src/components/formControls/controlWrapper/style.ts
@@ -32,7 +32,7 @@ export const StyledWrapper = styled('div')<{}>`
 
 export const StyledLabel = styled('div')<Partial<Props>>`
   width: 100%;
-  font-family: ${p => p.theme.fontFamily.body};
+  font-family: ${p => p.theme.legacy.fontFamily.body};
   line-height: normal;
   font-size: 14px;
   font-weight: 600;

--- a/src/components/formControls/radio/style.ts
+++ b/src/components/formControls/radio/style.ts
@@ -2,7 +2,7 @@
  * License. v. 2.0. If a copy of the MPL was not distributed with this file.
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import styled, { css, ThemedStyledProps } from '../../../theme'
+import styled, { css, StyledProps } from 'styled-components'
 import { Size } from './index'
 
 interface StyleProps {
@@ -11,7 +11,7 @@ interface StyleProps {
   selected?: boolean
 }
 
-const getThemeSizes = (p: ThemedStyledProps<StyleProps>) => {
+const getThemeSizes = (p: StyledProps<StyleProps>) => {
   let fillSize = '8'
   let circleSize = '18'
   let fontSize = '14'
@@ -31,14 +31,14 @@ const getThemeSizes = (p: ThemedStyledProps<StyleProps>) => {
   `
 }
 
-const getThemeColors = (p: ThemedStyledProps<StyleProps>, selected: boolean | undefined) => {
-  let fillColor = p.theme.color.brandBat
-  let borderColor = p.theme.color.subtleActive
+const getThemeColors = (p: StyledProps<StyleProps>, selected: boolean | undefined) => {
+  let fillColor = css`${p.theme.legacy.color.brandBat}`
+  let borderColor = p.theme.legacy.color.subtleActive
 
   if (!p.disabled) {
     borderColor = selected
-      ? p.theme.color.brandBat
-      : p.theme.color.brandBatActive
+      ? p.theme.legacy.color.brandBat
+      : p.theme.legacy.color.brandBatActive
   }
 
   return css`
@@ -47,8 +47,8 @@ const getThemeColors = (p: ThemedStyledProps<StyleProps>, selected: boolean | un
   `
 }
 
-export const StyledLabel = styled('label')<StyleProps>`
-  ${p => getThemeSizes(p)}
+export const StyledLabel = styled.label<StyleProps>`
+  ${getThemeSizes}
   line-height: 1.3;
   display: flex;
   margin-bottom: 30px;

--- a/src/components/formControls/select/style.ts
+++ b/src/components/formControls/select/style.ts
@@ -52,7 +52,7 @@ export const StyledWrapper = styled('div')<StyleProps>`
 export const StyledSelectWrapper = styled('div')<StyleProps>`
   position: relative;
   outline: 0;
-  font-family: ${p => p.theme.fontFamily.body};
+  font-family: ${p => p.theme.legacy.fontFamily.body};
 `
 
 export const StyledSelect = styled('div')<StyleProps>`
@@ -129,7 +129,7 @@ export const StyledOptionsOverlay = styled('div')<StyleProps>`
   left: 0;
   width: 100%;
   height: 100%;
-  background: ${p => p.theme.color.modalOverlayBackground};
+  background: ${p => p.theme.legacy.color.modalOverlayBackground};
   align-items: center;
   z-index: 999;
   justify-content: center;
@@ -137,7 +137,7 @@ export const StyledOptionsOverlay = styled('div')<StyleProps>`
 
 export const StyledOptionsModal = styled('div')<StyleProps>`
   border-radius: 4px;
-  background: ${p => p.theme.color.primaryBackground};
+  background: ${p => p.theme.legacy.color.primaryBackground};
   height: 30%;
   width: 50%;
   z-index: 9999;
@@ -161,7 +161,7 @@ export const StyledOptionsModal = styled('div')<StyleProps>`
 `
 
 export const StyledSelectTitle = styled('span')<StyleProps>`
-  color: ${p => p.theme.color.defaultControlActive};
+  color: ${p => p.theme.legacy.color.defaultControlActive};
   display: block;
   font-size: 16px;
   font-weight: 600;
@@ -169,7 +169,7 @@ export const StyledSelectTitle = styled('span')<StyleProps>`
   line-height: 32px;
   margin-bottom: 30px;
   text-align: left;
-  font-family: ${p => p.theme.fontFamily.body};
+  font-family: ${p => p.theme.legacy.fontFamily.body};
 `
 
 export const StyledModalContent = styled('div')<StyleProps>`

--- a/src/components/formControls/textareaClipboard/style.ts
+++ b/src/components/formControls/textareaClipboard/style.ts
@@ -10,7 +10,7 @@ export const StyledWrapper = styled('div')<{}>`
   padding: 10px;
   border: 1px solid #DFDFE8;
   border-radius: 6px;
-  font-family: ${p => p.theme.fontFamily.body};
+  font-family: ${p => p.theme.legacy.fontFamily.body};
 
   &:focus-within {
     border-color: #A1A8F2;

--- a/src/components/formControls/toggle/style.ts
+++ b/src/components/formControls/toggle/style.ts
@@ -79,7 +79,7 @@ export const StyledBullet = styled('div')<Props>`
 export const StyledText = styled('div')<Props>`
   color: #838391;
   font-size: ${(p) => p.size === 'small' ? '12px' : '14px'};
-  font-family: ${p => p.theme.fontFamily.body};
+  font-family: ${p => p.theme.legacy.fontFamily.body};
   text-align: right;
   letter-spacing: 0.4px;
   text-transform: uppercase;

--- a/src/components/layout/card/style.ts
+++ b/src/components/layout/card/style.ts
@@ -24,11 +24,11 @@ export const Card = styled('div')<StyledCardProps>`
   width: 100%;
   min-height: auto;
   margin: 0;
-  background-color: ${p => p.theme.color.panelBackground};
+  background-color: ${p => p.theme.legacy.color.panelBackground};
   border-radius: 4px;
   box-shadow: ${p => `0 2px 4px rgba(0, 0, 0, ${getShadowOpacity(p.emphasis)})`};
   font-size: inherit;
-  font-family: ${p => p.theme.fontFamily.body};
+  font-family: ${p => p.theme.legacy.fontFamily.body};
   box-sizing: border-box;
   position: relative;
 `

--- a/src/components/layout/tabs/style.ts
+++ b/src/components/layout/tabs/style.ts
@@ -11,7 +11,7 @@ interface StyleProps {
 export const StyledTabWrapper = styled('div')<{}>`
   border-bottom: 1px solid #DFDFE8;
   text-align: center;
-  font-family: ${p => p.theme.fontFamily.body};
+  font-family: ${p => p.theme.legacy.fontFamily.body};
 `
 
 export const StyledTab = styled('div')<StyleProps>`

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,10 @@
     "allowSyntheticDefaultImports": false,
     "skipLibCheck": true
   },
-
+  "typeRoots": [
+    "./node_modules/@types",
+    "./definitions"
+  ],
   "include": [
     "./definitions",
     "./src",


### PR DESCRIPTION
…so that any uses of this theme are seen as deprecated and do not conflict with modern theme properties
